### PR TITLE
feat: open browser on vibe login + show web url on leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibetime-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Track what you ship in AI coding sessions",
   "type": "module",
   "bin": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,7 @@
 export const API_BASE = process.env.VIBE_API ?? 'https://api.vibetime.club';
 
+export const WEB_BASE = process.env.VIBE_WEB ?? 'https://vibetime.club';
+
 export const GITHUB_CLIENT_ID = process.env.VIBE_GITHUB_CLIENT_ID ?? 'Ov23liTitygBey3l86qT';
 
 interface RequestOptions {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 import { chmodSync, existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import open from 'open';
 import { VIBE_DIR, ensureVibeDir } from './config.js';
 import { request, GITHUB_CLIENT_ID, ApiError } from './api.js';
 import { renderLoginPrompt } from './render.js';
@@ -73,6 +74,9 @@ export async function login(): Promise<void> {
 
   const verificationUrl = `${device.verification_uri}?user_code=${encodeURIComponent(device.user_code)}`;
   console.log(renderLoginPrompt(device.user_code, verificationUrl));
+
+  // try to open the browser to the prefilled approval URL; silently fall back to the printed link
+  open(verificationUrl).catch(() => {});
 
   const accessToken = await pollGithub(device);
   if (!accessToken) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { initShellHooks, removeShellHooks } from './init.js';
 import { login, logout, readAuth } from './auth.js';
 import { fetchLeaderboard } from './leaderboard.js';
 import { flushPendingSubmissions } from './submit.js';
+import { WEB_BASE } from './api.js';
 import chalk from 'chalk';
 import open from 'open';
 import { createRequire } from 'node:module';
@@ -152,7 +153,7 @@ program
     try {
       const data = await fetchLeaderboard();
       const auth = readAuth();
-      console.log(renderLeaderboard(data.entries, auth?.handle));
+      console.log(renderLeaderboard(data.entries, `${WEB_BASE}/leaderboard`, auth?.handle));
     } catch (e) {
       const msg = e instanceof Error ? e.message : 'unknown error';
       console.log(`\n  ${RED('✗')} vibe: could not load leaderboard (${msg})\n`);

--- a/src/render.ts
+++ b/src/render.ts
@@ -144,11 +144,12 @@ export function renderLoginPrompt(userCode: string, verificationUri: string): st
   ].join('\n');
 }
 
-export function renderLeaderboard(entries: LeaderboardEntry[], currentHandle?: string): string {
+export function renderLeaderboard(entries: LeaderboardEntry[], webUrl: string, currentHandle?: string): string {
   const header = `${PURPLE('◆')} vibe  ·  leaderboard  ·  shipped · last 7d`;
+  const footer = `  ${DIM(webUrl)}`;
 
   if (entries.length === 0) {
-    return `\n${header}\n\n  no shipped sessions yet this week. be the first.\n`;
+    return ['', header, '', '  no shipped sessions yet this week. be the first.', '', footer, ''].join('\n');
   }
 
   const maxHandleLen = Math.max(...entries.map(e => e.handle.length), 8);
@@ -163,7 +164,7 @@ export function renderLeaderboard(entries: LeaderboardEntry[], currentHandle?: s
     return isMe ? PURPLE(line) : line;
   });
 
-  return ['', header, '', ...rows, ''].join('\n');
+  return ['', header, '', ...rows, '', footer, ''].join('\n');
 }
 
 export function renderLog(sessions: Session[]): string {


### PR DESCRIPTION
Two small CLI polish wins observed in real use after 0.4.0.

## `vibe login` auto-opens the browser

Before: code + URL printed, user had to manually copy the URL into a browser.

After: the prefilled `https://github.com/login/device?user_code=XXXX-XXXX` URL is passed to \`open\` (already a runtime dep, used by \`vibe share --html\`). Code stays visible in the box for the rare case the auto-open fails (headless servers, SSH without X forwarding). Matches the behavior of \`gh auth login\`, \`wrangler login\`, \`aws sso login\`.

## \`vibe leaderboard\` shows the web URL

Before:
\`\`\`
◆ vibe  ·  leaderboard  ·  shipped · last 7d

  1  iamnotstatic  ·    4 shipped
\`\`\`

After:
\`\`\`
◆ vibe  ·  leaderboard  ·  shipped · last 7d

  1  iamnotstatic  ·    4 shipped

  https://vibetime.club/leaderboard
\`\`\`

Dimmed footer so it reads as a hint, not data. Empty-state path also gets the footer so new users see where the full web view lives. Modern terminals auto-link the URL.

## Other

- Adds \`WEB_BASE\` const to \`src/api.ts\` (symmetric with \`API_BASE\`, env-overridable via \`VIBE_WEB\` for local testing).
- Version bump to \`0.4.1\`.
- No new dependencies. Runtime deps still: chalk, commander, open.

## Test plan

- [x] \`npm run build\` clean
- [x] \`vibe --version\` prints \`0.4.1\`
- [x] \`vibe login\` opens the browser to the prefilled GitHub URL (try on macOS; on Linux/SSH-without-display the auto-open silently fails and the printed URL is the fallback)
- [x] \`vibe leaderboard\` shows the \`https://vibetime.club/leaderboard\` footer in both populated and empty states
- [x] \`VIBE_WEB=http://localhost:8787 vibe leaderboard\` overrides the footer URL