### PR TITLE
leaderboard UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">Track what you actually ship with AI.</p>
 
-<p align="center">Vibetime wraps Claude Code, Codex, and Gemini and prints a session summary every time you're done. No config, no account, no daemon.</p>
+<p align="center">Vibetime wraps Claude Code, Codex, and Gemini and prints a session summary every time you're done. No config, no daemon, no account by default.</p>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/iamnotstatic/vibetime/main/assets/status.png" alt="vibe status" />
@@ -49,6 +49,8 @@ Every time you close a Claude Code, Codex, or Gemini session:
 ╰─────────────────────────────────────────────╯
 ```
 
+Every `shipped` session counts on the leaderboard.
+
 Sessions are scored by what happened in git:
 
 | tier | bar | meaning |
@@ -61,25 +63,6 @@ Sessions are scored by what happened in git:
 | interrupted | `░░░░░░░░░░` | session killed or crashed |
 
 **How duration works** — Vibetime polls your git state every 30 seconds. If no file changes, commits, or staging activity are detected for 30 minutes, the idle time is excluded from your session duration. Laptop sleep and background idle are automatically handled. Non-git projects use wall-clock time.
-
-## Share your week
-
-Run `vibe share` to print your weekly card. Press `h` to open the HTML version — copy it, screenshot it, post it.
-
-Streaks track consecutive days you shipped. If you shipped yesterday but not yet today, your streak shows ⏳ — you still have time.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/iamnotstatic/vibetime/main/assets/share-terminal.png" width="400" alt="vibe share terminal" />
-  <img src="https://raw.githubusercontent.com/iamnotstatic/vibetime/main/assets/share-card.png" width="400" alt="vibe share html card" />
-</p>
-
-## Adding more tools
-
-Vibetime wraps any AI CLI. To track a tool not listed above:
-
-```
-vibe config add-tool aider
-```
 
 ## Leaderboard (opt-in)
 
@@ -100,6 +83,25 @@ Once logged in, the endcard renders as usual and the session submits in the back
 **Submitted fields:** `tool`, `startedAt`, `endedAt`, `durationSeconds`, `commits`, `linesAdded`, `linesRemoved`, `filesTouched`, `momentum`, and a SHA-256 hash of the project name. Branch names, raw repo names, exit codes, and your local handle never leave the machine.
 
 `vibe logout` removes `~/.vibe/auth.json` and submission stops immediately.
+
+## Share your week
+
+Run `vibe share` to print your weekly card. Press `h` to open the HTML version — copy it, screenshot it, post it.
+
+Streaks track consecutive days you shipped. If you shipped yesterday but not yet today, your streak shows ⏳ — you still have time.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/iamnotstatic/vibetime/main/assets/share-terminal.png" width="400" alt="vibe share terminal" />
+  <img src="https://raw.githubusercontent.com/iamnotstatic/vibetime/main/assets/share-card.png" width="400" alt="vibe share html card" />
+</p>
+
+## Adding more tools
+
+Vibetime wraps any AI CLI. To track a tool not listed above:
+
+```
+vibe config add-tool aider
+```
 
 ## Commands
 

--- a/server/src/routes/leaderboard.ts
+++ b/server/src/routes/leaderboard.ts
@@ -26,13 +26,24 @@ interface DailyCount {
   n: number;
 }
 
+export interface HeatmapDay {
+  day: string;
+  n: number;
+}
+
 export interface LeaderboardEntry {
   rank: number;
   handle: string;
   avatarUrl: string | null;
   shippedCount: number;
   lastShippedAt: string;
-  recentDays: number[];
+  recentDays: HeatmapDay[];
+}
+
+export interface LeaderboardData {
+  entries: LeaderboardEntry[];
+  devCount: number;
+  sessionCount: number;
 }
 
 function parseWindow(value: string | null): Window {
@@ -40,9 +51,17 @@ function parseWindow(value: string | null): Window {
   return 'week';
 }
 
-async function buildEntries(env: Env, window: Window): Promise<LeaderboardEntry[]> {
+async function buildData(env: Env, window: Window): Promise<LeaderboardData> {
   const sinceMs = window === 'all' ? 0 : Date.now() - WINDOWS[window];
   const sinceIso = new Date(sinceMs).toISOString();
+
+  const totalsRes = await env.DB.prepare(
+    `SELECT COUNT(DISTINCT user_github_id) AS dev_count, COUNT(*) AS session_count
+     FROM sessions
+     WHERE momentum = 'shipped' AND started_at > ?`,
+  ).bind(sinceIso).first<{ dev_count: number; session_count: number }>();
+  const devCount = totalsRes?.dev_count ?? 0;
+  const sessionCount = totalsRes?.session_count ?? 0;
 
   const topRes = await env.DB.prepare(
     `SELECT u.github_id, u.handle, u.avatar_url,
@@ -57,7 +76,7 @@ async function buildEntries(env: Env, window: Window): Promise<LeaderboardEntry[
   ).bind(sinceIso).all<LeaderboardRow>();
 
   const rows = topRes.results ?? [];
-  if (rows.length === 0) return [];
+  if (rows.length === 0) return { entries: [], devCount, sessionCount };
 
   const heatmapSince = new Date(Date.now() - HEATMAP_DAYS * 24 * 60 * 60 * 1000).toISOString();
   const placeholders = rows.map(() => '?').join(',');
@@ -83,7 +102,7 @@ async function buildEntries(env: Env, window: Window): Promise<LeaderboardEntry[
     dayKeys.push(d.toISOString().slice(0, 10));
   }
 
-  return rows.map((r, i) => {
+  const entries = rows.map((r, i) => {
     const userDays = dailyByUser.get(r.github_id) ?? new Map();
     return {
       rank: i + 1,
@@ -91,25 +110,29 @@ async function buildEntries(env: Env, window: Window): Promise<LeaderboardEntry[
       avatarUrl: r.avatar_url,
       shippedCount: r.shipped_count,
       lastShippedAt: r.last_shipped_at,
-      recentDays: dayKeys.map((k) => userDays.get(k) ?? 0),
+      recentDays: dayKeys.map((k) => ({ day: k, n: userDays.get(k) ?? 0 })),
     };
   });
+
+  return { entries, devCount, sessionCount };
 }
 
 export async function leaderboardJson(request: Request, env: Env): Promise<Response> {
   const window = parseWindow(new URL(request.url).searchParams.get('window'));
-  const entries = await buildEntries(env, window);
+  const data = await buildData(env, window);
   return json({
     window,
     updatedAt: new Date().toISOString(),
-    entries,
+    devCount: data.devCount,
+    sessionCount: data.sessionCount,
+    entries: data.entries,
   }, { headers: { 'cache-control': 'public, max-age=60' } });
 }
 
 export async function leaderboardHtml(request: Request, env: Env): Promise<Response> {
   const window = parseWindow(new URL(request.url).searchParams.get('window'));
-  const entries = await buildEntries(env, window);
-  return html(renderLeaderboard(entries, window, new Date()), {
+  const data = await buildData(env, window);
+  return html(renderLeaderboard(data, window, new Date()), {
     headers: {
       'cache-control': 'public, max-age=60',
       'content-security-policy': "default-src 'self'; img-src https://avatars.githubusercontent.com; style-src 'unsafe-inline'; base-uri 'self'; form-action 'self'",

--- a/server/src/views/leaderboard.ts
+++ b/server/src/views/leaderboard.ts
@@ -1,4 +1,4 @@
-import type { LeaderboardEntry } from '../routes/leaderboard.js';
+import type { HeatmapDay, LeaderboardData } from '../routes/leaderboard.js';
 
 type Window = 'week' | 'month' | 'all';
 
@@ -18,12 +18,11 @@ function relativeTime(iso: string, now: Date): string {
   return iso.slice(0, 10);
 }
 
-function heatmapCells(recent: number[]): string {
-  return recent.map((n) => {
-    if (n === 0) return `<span class="cell cell-0" aria-hidden="true"></span>`;
-    if (n === 1) return `<span class="cell cell-1" aria-hidden="true"></span>`;
-    if (n <= 3) return `<span class="cell cell-2" aria-hidden="true"></span>`;
-    return `<span class="cell cell-3" aria-hidden="true"></span>`;
+function heatmapCells(recent: HeatmapDay[]): string {
+  return recent.map(({ day, n }) => {
+    const cls = n === 0 ? 'cell-0' : n === 1 ? 'cell-1' : n <= 3 ? 'cell-2' : 'cell-3';
+    const noun = n === 1 ? 'shipped session' : 'shipped sessions';
+    return `<span class="cell ${cls}" title="${escapeHtml(day)} · ${n} ${noun}" aria-hidden="true"></span>`;
   }).join('');
 }
 
@@ -32,15 +31,26 @@ function tab(label: string, value: Window, active: Window): string {
   return `<a class="${cls}" href="/leaderboard?window=${value}">${escapeHtml(label)}</a>`;
 }
 
-const WINDOW_LABEL: Record<Window, string> = {
-  week: 'last 7 days',
-  month: 'last 30 days',
-  all: 'all time',
+const SCALE_WINDOW_LABEL: Record<Window, string> = {
+  week: 'this week',
+  month: 'this month',
+  all: 'all-time',
 };
 
-export function renderLeaderboard(entries: LeaderboardEntry[], window: Window, updatedAt: Date): string {
+export function renderLeaderboard(data: LeaderboardData, window: Window, updatedAt: Date): string {
+  const { entries, devCount, sessionCount } = data;
+  const devNoun = devCount === 1 ? 'developer' : 'developers';
+  const sessionNoun = sessionCount === 1 ? 'shipped session' : 'shipped sessions';
+  const scaleLine = entries.length === 0
+    ? ''
+    : `<p class="scale"><strong>${devCount}</strong> ${devNoun} · <strong>${sessionCount}</strong> ${sessionNoun} ${escapeHtml(SCALE_WINDOW_LABEL[window])}</p>`;
   const tableRows = entries.length === 0
-    ? `<tr><td colspan="5" class="empty">no shipped sessions ${escapeHtml(WINDOW_LABEL[window])} yet</td></tr>`
+    ? `<tr><td colspan="5" class="empty">
+        <div class="empty-msg">nothing shipped. yet.</div>
+        <pre class="empty-cmd">npm i -g vibetime-cli
+vibe init
+vibe login</pre>
+      </td></tr>`
     : entries.map((e) => {
         const handle = escapeHtml(e.handle);
         const avatar = e.avatarUrl
@@ -51,7 +61,7 @@ export function renderLeaderboard(entries: LeaderboardEntry[], window: Window, u
           <td class="${rankClass}">${e.rank}</td>
           <td class="who"><a href="https://github.com/${handle}" rel="nofollow noopener">${avatar}<span>${handle}</span></a></td>
           <td class="shipped">${e.shippedCount}</td>
-          <td class="activity"><span class="heatmap" title="shipped sessions, last 7 days">${heatmapCells(e.recentDays)}</span></td>
+          <td class="activity"><span class="heatmap">${heatmapCells(e.recentDays)}</span></td>
           <td class="last">${escapeHtml(relativeTime(e.lastShippedAt, updatedAt))}</td>
         </tr>`;
       }).join('');
@@ -69,36 +79,42 @@ export function renderLeaderboard(entries: LeaderboardEntry[], window: Window, u
   main { max-width: 760px; margin: 0 auto; }
   header { margin-bottom: 24px; }
   h1 { font-size: 18px; margin: 0; color: #a78bfa; font-weight: 600; letter-spacing: 0.5px; }
+  .tagline { color: #999; font-size: 13px; margin: 6px 0 0; }
+  .scale { color: #888; font-size: 12px; margin: 6px 0 0; }
+  .scale strong { color: #c4b5fd; font-weight: 600; font-variant-numeric: tabular-nums; }
   .sub { color: #666; font-size: 12px; margin: 4px 0 0; }
   .tabs { display: flex; gap: 4px; margin: 20px 0 16px; border-bottom: 1px solid #1a1a1a; }
   .tab { color: #666; text-decoration: none; padding: 8px 12px; font-size: 13px; border-bottom: 2px solid transparent; margin-bottom: -1px; }
   .tab:hover { color: #a78bfa; }
   .tab-active { color: #e5e5e5; border-bottom-color: #a78bfa; }
   table { width: 100%; border-collapse: collapse; }
-  thead th { text-align: left; padding: 8px 8px 12px; color: #555; font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; border-bottom: 1px solid #1a1a1a; }
+  thead th { text-align: left; padding: 8px 8px 12px; color: #555; font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.6px; white-space: nowrap; border-bottom: 1px solid #1a1a1a; }
   thead th.col-rank, thead th.col-shipped { text-align: right; }
   thead th.col-last { text-align: right; }
   tbody td { padding: 12px 8px; border-bottom: 1px solid #141414; font-size: 14px; vertical-align: middle; }
   tbody tr:hover td { background: #111; }
   td.rank { width: 44px; color: #666; text-align: right; font-variant-numeric: tabular-nums; }
   td.rank-top { color: #a78bfa; font-weight: 600; }
-  td.shipped { width: 80px; text-align: right; color: #a78bfa; font-variant-numeric: tabular-nums; font-weight: 600; }
+  td.shipped { width: 80px; text-align: right; color: #a78bfa; font-variant-numeric: tabular-nums; font-weight: 600; font-size: 16px; }
   td.activity { width: 110px; }
   td.last { width: 100px; text-align: right; color: #666; font-size: 12px; font-variant-numeric: tabular-nums; }
   td.who a { color: #e5e5e5; text-decoration: none; display: flex; align-items: center; gap: 10px; }
   td.who a:hover { color: #a78bfa; }
   td.who img, .avatar-fallback { border-radius: 50%; display: block; width: 24px; height: 24px; }
   .avatar-fallback { background: #1a1a1a; }
-  td.empty { text-align: center; color: #555; padding: 40px 0; }
+  td.empty { text-align: center; color: #666; padding: 40px 16px; }
+  .empty-msg { margin-bottom: 16px; }
+  .empty-cmd { color: #a78bfa; background: #111; padding: 10px 14px; border-radius: 4px; display: inline-block; margin: 0; font-family: inherit; font-size: 13px; text-align: left; }
+  .legend { display: flex; align-items: center; justify-content: flex-end; gap: 4px; margin: 12px 0 0; color: #555; font-size: 11px; }
+  .legend .cell { width: 8px; height: 8px; }
   .heatmap { display: inline-flex; gap: 3px; }
   .cell { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
   .cell-0 { background: #1a1a1a; }
   .cell-1 { background: #3b2a5d; }
   .cell-2 { background: #6d4ec8; }
   .cell-3 { background: #a78bfa; }
-  footer { color: #444; font-size: 11px; margin-top: 32px; padding-top: 16px; border-top: 1px solid #141414; }
+  footer { color: #444; font-size: 11px; margin-top: 20px; padding-top: 16px; border-top: 1px solid #141414; }
   footer .definition { margin-bottom: 8px; }
-  footer .links { text-align: center; }
   footer a { color: #666; }
   @media (max-width: 600px) {
     td.activity, thead th.col-activity { display: none; }
@@ -110,7 +126,9 @@ export function renderLeaderboard(entries: LeaderboardEntry[], window: Window, u
 <main>
   <header>
     <h1>◆ vibetime · leaderboard</h1>
-    <p class="sub">shipped sessions · updated ${updatedAt.toISOString().slice(0, 16).replace('T', ' ')}Z</p>
+    <p class="tagline">ranked by what you ship</p>
+    ${scaleLine}
+    <p class="sub">updated ${updatedAt.toISOString().slice(0, 16).replace('T', ' ')}Z</p>
   </header>
   <nav class="tabs">
     ${tab('this week', 'week', window)}
@@ -123,7 +141,7 @@ export function renderLeaderboard(entries: LeaderboardEntry[], window: Window, u
         <th class="col-rank">#</th>
         <th class="col-developer">developer</th>
         <th class="col-shipped">shipped</th>
-        <th class="col-activity">activity</th>
+        <th class="col-activity">last 7 days</th>
         <th class="col-last">last shipped</th>
       </tr>
     </thead>
@@ -131,8 +149,16 @@ export function renderLeaderboard(entries: LeaderboardEntry[], window: Window, u
       ${tableRows}
     </tbody>
   </table>
+  <div class="legend" aria-hidden="true">
+    last 7 days: less
+    <span class="cell cell-0"></span>
+    <span class="cell cell-1"></span>
+    <span class="cell cell-2"></span>
+    <span class="cell cell-3"></span>
+    more
+  </div>
   <footer>
-    <div class="definition"><strong style="color:#777">shipped</strong> = a session with at least one commit and meaningful changes (≥50 lines or ≥3 files). <strong style="color:#777">activity</strong> shows the last 7 days regardless of the tab selected.</div>
+    <div class="definition"><strong style="color:#777">shipped</strong> = a session with at least one commit and meaningful changes (≥50 lines or ≥3 files).</div>
     <div class="links"><a href="https://github.com/iamnotstatic/vibetime">github.com/iamnotstatic/vibetime</a> &nbsp;·&nbsp; <code>npm i -g vibetime-cli</code></div>
   </footer>
 </main>


### PR DESCRIPTION
## Summary

UI and copy polish for vibetime.club/leaderboard plus README reorder so `vibe login` is discoverable from the launch tweet path. Deployed to prod alongside this PR.

### Leaderboard page
- New tagline: `ranked by what you ship`
- Window-aware scale line: `N developers · M shipped sessions this week`
- Empty state: `nothing shipped. yet.` with install commands CTA
- Heatmap: per-cell tooltips (`YYYY-MM-DD · N shipped sessions`) and a legend strip below the table
- Column rename: `activity` → `last 7 days`
- `shipped` column raised to 16px for visual hierarchy
- Footer alignment unified (definition + links share left edge)
- Removed redundant heatmap wrapper title

### API
- `/leaderboard.json` adds `devCount` and `sessionCount` fields
- `entries[].recentDays` changed from `number[]` to `{ day, n }[]`
- CLI consumer (`fetchLeaderboard`) reads neither field, so backward-compatible

### README
- `## Leaderboard (opt-in)` moved to directly after `## What you get`
- One-line bridge under the endcard mockup: `Every shipped session counts on the leaderboard.`
- Tagline qualifier: `no account` → `no account by default`

## Test plan

- [x] `npm run typecheck` clean (server)
- [x] `npm run build` clean (root CLI)
- [x] Local render verified (empty + populated states)
- [x] Prod smoke: `curl https://vibetime.club/leaderboard` → 200, new tagline present
- [x] Prod smoke: `curl https://vibetime.club/leaderboard.json` → includes `devCount` and `sessionCount`
- [x] `vibe leaderboard` CLI still renders correctly against prod