### PR TITLE
v0.4.2: in-progress submissions and foundation work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibetime-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Track what you ship in AI coding sessions",
   "type": "module",
   "bin": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,9 @@ import { submitSession } from './routes/sessions.js';
 import { leaderboardJson, leaderboardHtml } from './routes/leaderboard.js';
 import { error } from './http.js';
 
+// bump this when a new CLI release should be recommended to clients
+const CLI_RECOMMENDED_VERSION = '0.4.2';
+
 const CORS_HEADERS = {
   'access-control-allow-origin': '*',
   'access-control-allow-methods': 'GET, POST, OPTIONS',
@@ -14,6 +17,7 @@ const CORS_HEADERS = {
 function withCors(res: Response): Response {
   const headers = new Headers(res.headers);
   for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+  headers.set('x-cli-recommended-version', CLI_RECOMMENDED_VERSION);
   return new Response(res.body, { status: res.status, headers });
 }
 

--- a/server/src/ratelimit.ts
+++ b/server/src/ratelimit.ts
@@ -1,7 +1,7 @@
 import type { Env } from './env.js';
 
 const WINDOW_SECONDS = 3600;
-const MAX_PER_WINDOW = 30;
+const MAX_PER_WINDOW = 60;
 
 export async function checkAndRecord(env: Env, userGithubId: number): Promise<boolean> {
   const now = Math.floor(Date.now() / 1000);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -2,7 +2,7 @@ import type { Env } from '../env.js';
 import { error, json } from '../http.js';
 import { signJwt } from '../jwt.js';
 
-const JWT_TTL_SECONDS = 90 * 24 * 60 * 60;
+const JWT_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 interface GithubUser {
   id: number;

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -23,7 +23,7 @@ interface IncomingSession {
   linesAdded: number;
   linesRemoved: number;
   filesTouched: number;
-  momentum: string;
+  momentum?: string;
 }
 
 function parseSession(raw: unknown): IncomingSession | string {
@@ -39,8 +39,8 @@ function parseSession(raw: unknown): IncomingSession | string {
   if (typeof s.linesAdded !== 'number' || s.linesAdded < 0) return 'invalid linesAdded';
   if (typeof s.linesRemoved !== 'number' || s.linesRemoved < 0) return 'invalid linesRemoved';
   if (typeof s.filesTouched !== 'number' || s.filesTouched < 0) return 'invalid filesTouched';
-  // momentum may still arrive from older clients; we accept it for backward compat but ignore it below
-  if (typeof s.momentum !== 'string' || !VALID_TIERS.has(s.momentum)) return 'invalid momentum';
+  // momentum is now optional — server is authoritative — but validate the shape if old clients still send it
+  if (s.momentum !== undefined && (typeof s.momentum !== 'string' || !VALID_TIERS.has(s.momentum))) return 'invalid momentum';
   return s as unknown as IncomingSession;
 }
 

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -2,6 +2,7 @@ import type { Env } from '../env.js';
 import { error, json } from '../http.js';
 import { requireAuth } from '../auth-middleware.js';
 import { checkAndRecord } from '../ratelimit.js';
+import { scoreSession } from '../score.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const VALID_TIERS = new Set(['shipped', 'progressed', 'tinkering', 'exploring', 'idle', 'interrupted']);
@@ -38,6 +39,7 @@ function parseSession(raw: unknown): IncomingSession | string {
   if (typeof s.linesAdded !== 'number' || s.linesAdded < 0) return 'invalid linesAdded';
   if (typeof s.linesRemoved !== 'number' || s.linesRemoved < 0) return 'invalid linesRemoved';
   if (typeof s.filesTouched !== 'number' || s.filesTouched < 0) return 'invalid filesTouched';
+  // momentum may still arrive from older clients; we accept it for backward compat but ignore it below
   if (typeof s.momentum !== 'string' || !VALID_TIERS.has(s.momentum)) return 'invalid momentum';
   return s as unknown as IncomingSession;
 }
@@ -64,7 +66,15 @@ export async function submitSession(request: Request, env: Env): Promise<Respons
 
   if (!(await checkAndRecord(env, auth.sub))) return error(429, 'rate limit exceeded');
 
-  if (parsed.momentum === 'shipped') {
+  // server is authoritative for momentum — recompute from raw stats and ignore whatever the client sent
+  const momentum = scoreSession({
+    commits: parsed.commits,
+    linesAdded: parsed.linesAdded,
+    linesRemoved: parsed.linesRemoved,
+    filesTouched: parsed.filesTouched,
+  });
+
+  if (momentum === 'shipped') {
     const since = new Date(Date.now() - SHIPPED_WINDOW_MS).toISOString();
     const existing = await env.DB.prepare(
       `SELECT COUNT(*) AS n FROM sessions WHERE user_github_id = ? AND momentum = 'shipped' AND started_at >= ? AND id != ?`,
@@ -93,7 +103,7 @@ export async function submitSession(request: Request, env: Env): Promise<Respons
   ).bind(
     parsed.id, auth.sub, parsed.tool, parsed.projectHash, parsed.startedAt, parsed.endedAt,
     parsed.durationSeconds, parsed.commits, parsed.linesAdded, parsed.linesRemoved,
-    parsed.filesTouched, parsed.momentum, submittedAt,
+    parsed.filesTouched, momentum, submittedAt,
   ).run();
 
   await env.DB.prepare(`UPDATE users SET last_seen_at = ? WHERE github_id = ?`).bind(submittedAt, auth.sub).run();

--- a/server/src/score.ts
+++ b/server/src/score.ts
@@ -1,0 +1,23 @@
+export type MomentumTier = 'shipped' | 'progressed' | 'tinkering' | 'exploring' | 'idle';
+
+export interface Stats {
+  commits: number;
+  linesAdded: number;
+  linesRemoved: number;
+  filesTouched: number;
+}
+
+const THRESHOLD_LINES = 50;
+const THRESHOLD_FILES = 3;
+
+export function scoreSession(stats: Stats): MomentumTier {
+  const hasCommit = stats.commits > 0;
+  const linesNet = stats.linesAdded + stats.linesRemoved;
+  const meaningful = linesNet > THRESHOLD_LINES || stats.filesTouched > THRESHOLD_FILES;
+
+  if (hasCommit && meaningful) return 'shipped';
+  if (hasCommit && !meaningful) return 'progressed';
+  if (!hasCommit && meaningful) return 'tinkering';
+  if (!hasCommit && linesNet > 0) return 'exploring';
+  return 'idle';
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,31 @@
+import { createRequire } from 'node:module';
+
 export const API_BASE = process.env.VIBE_API ?? 'https://api.vibetime.club';
 
 export const WEB_BASE = process.env.VIBE_WEB ?? 'https://vibetime.club';
 
 export const GITHUB_CLIENT_ID = process.env.VIBE_GITHUB_CLIENT_ID ?? 'Ov23liTitygBey3l86qT';
+
+const require = createRequire(import.meta.url);
+export const CLI_VERSION: string = require('../package.json').version;
+
+let recommendedVersion: string | null = null;
+
+export function getRecommendedVersion(): string | null {
+  return recommendedVersion;
+}
+
+function isNewerVersion(a: string, b: string): boolean {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const ai = pa[i] ?? 0;
+    const bi = pb[i] ?? 0;
+    if (ai > bi) return true;
+    if (ai < bi) return false;
+  }
+  return false;
+}
 
 interface RequestOptions {
   method?: 'GET' | 'POST';
@@ -26,7 +49,8 @@ export async function request<T>(path: string, opts: RequestOptions = {}): Promi
     method: opts.method ?? 'GET',
     headers: {
       'accept': 'application/json',
-      'user-agent': `vibetime-cli`,
+      'user-agent': `vibetime-cli/${CLI_VERSION}`,
+      'x-cli-version': CLI_VERSION,
       ...(opts.body !== undefined ? { 'content-type': 'application/json' } : {}),
       ...(opts.headers ?? {}),
     },
@@ -35,6 +59,10 @@ export async function request<T>(path: string, opts: RequestOptions = {}): Promi
   if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
 
   const res = await fetch(url, init);
+  const recommended = res.headers.get('x-cli-recommended-version');
+  if (recommended && isNewerVersion(recommended, CLI_VERSION)) {
+    recommendedVersion = recommended;
+  }
   const text = await res.text();
   let parsed: unknown = null;
   if (text) {

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -23,6 +23,22 @@ function buildPayload(s: Session): Record<string, unknown> {
   };
 }
 
+export async function submitInProgress(session: Session, budgetMs = 1500): Promise<void> {
+  const auth = readAuth();
+  if (!auth) return;
+  if (session.durationSeconds < 60) return;
+  try {
+    await request<{ ok: true; submittedAt: string }>('/sessions', {
+      method: 'POST',
+      body: buildPayload(session),
+      headers: { authorization: `Bearer ${auth.jwt}` },
+      timeoutMs: budgetMs,
+    });
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 401) clearAuth();
+  }
+}
+
 export async function flushPendingSubmissions(budgetMs: number): Promise<void> {
   const auth = readAuth();
   if (!auth) return;

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -5,9 +5,10 @@ import { isGitRepo, getHeadSha, getBranch, getProjectName, getDiffStats, getWork
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { renderEndcard } from './render.js';
-import { flushPendingSubmissions } from './submit.js';
+import { flushPendingSubmissions, submitInProgress } from './submit.js';
 
 const POLL_INTERVAL_MS = 30_000;
+const IN_PROGRESS_SUBMIT_INTERVAL_MS = 5 * 60_000;
 
 function reportSpawnError(tool: string, err: NodeJS.ErrnoException): void {
   if (err.code === 'ENOENT') {
@@ -73,6 +74,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
   let prevLinesAdded = initial.linesAdded;
   let prevLinesRemoved = initial.linesRemoved;
   let prevTreeState = hasGit ? getWorkingTreeFingerprint(cwd) : '';
+  let lastInProgressSubmitAt = 0;
   const poll = setInterval(async () => {
     try {
       const now = Date.now();
@@ -101,6 +103,14 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
         prevTreeState = treeState;
       }
       await updateSession(sessionId, snap);
+
+      if (snap.momentum === 'shipped') {
+        const sinceLast = Date.now() - lastInProgressSubmitAt;
+        if (lastInProgressSubmitAt === 0 || sinceLast >= IN_PROGRESS_SUBMIT_INTERVAL_MS) {
+          lastInProgressSubmitAt = Date.now();
+          submitInProgress({ ...session, ...snap }).catch(() => {});
+        }
+      }
     } catch {}
   }, POLL_INTERVAL_MS);
   poll.unref();

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -6,6 +6,8 @@ import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { renderEndcard } from './render.js';
 import { flushPendingSubmissions, submitInProgress } from './submit.js';
+import { getRecommendedVersion } from './api.js';
+import { PURPLE } from './colors.js';
 
 const POLL_INTERVAL_MS = 30_000;
 const IN_PROGRESS_SUBMIT_INTERVAL_MS = 5 * 60_000;
@@ -139,6 +141,12 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
     }
     if (showEndcard) console.log(renderEndcard({ ...session, ...final }));
     await flushPendingSubmissions(1500).catch(() => {});
+    if (showEndcard) {
+      const recommended = getRecommendedVersion();
+      if (recommended) {
+        console.log(`  ${PURPLE('◆')} vibe ${recommended} available · run: npm i -g vibetime-cli\n`);
+      }
+    }
     process.exit(exitCode);
   }
 


### PR DESCRIPTION
## Summary

Originally scoped as the in-progress submissions fix; expanded to bundle the foundation work that has to land in 0.4.2 before broader install. Once a CLI version is in the wild, ~30% of users never update, so the cost of skipping these is permanent for that cohort.

## What's in the box

### Feature

**In-progress submissions for shipped sessions.** Long-running sessions (multi-hour, all-day) previously never appeared on the leaderboard until they exited. The poll loop already updated local `vibe.json` every 30s but never POSTed. Now: when a snapshot crosses the shipped threshold, the wrapper POSTs immediately, then every 5 minutes while the session continues. End-of-session flush is unchanged and still owns the final submission.

### Foundation

**Server is authoritative for momentum.** `scoreSession` now runs server-side. CLI-sent `momentum` is accepted for backward compat but ignored. Closes the fraud vector (a patched CLI can't stamp anything as shipped anymore) and means threshold tuning is forever a server-only change. CLI keeps its own copy of the scoring logic for endcard display.

**JWT lifetime 90d to 365d.** 90 days meant the launch cohort would start hitting silent 401s in August. Buys nine more months. Proper refresh-token flow lands in v0.5.

**Version negotiation.** Outgoing requests send `X-Cli-Version`. Server responds with `X-Cli-Recommended-Version` (constant in `index.ts`, bump per release). When the recommended version is newer than what's running, the wrapper prints a one-line nudge after the endcard. 0.4.2 is the first version that can read this; bump the constant when 0.5 ships and 0.4.x users get pinged.

**Rate limit 30 to 60 per hour.** Headroom for the new in-progress submission cadence.

## Test plan

- [x] `npm run build` clean (CLI)
- [x] `npm run typecheck` clean (server)
- [x] Server deployed (version `75f6d396`)
- [x] `node dist/cli.js status` renders correctly
- [x] `curl https://vibetime.club/leaderboard.json` returns the new header (verified `x-cli-recommended-version: 0.4.2`)
- [x] Leaderboard JSON shape unchanged
- [ ] After `npm publish`: install 0.4.2, start a long claude session, watch in-progress submissions appear on the board within ~90s of crossing shipped
- [ ] When bumping `CLI_RECOMMENDED_VERSION` in a future deploy, confirm old CLIs print the nudge

## Risk

- Server momentum classification means existing in-flight sessions that were going to be classified as `shipped` client-side will now be classified server-side. Both copies of `scoreSession` use the same thresholds today (>50 lines or >3 files), so the classification result is identical. If they drift in the future, server wins.
- JWT bump only applies to new sign-ins. Existing tokens still expire at 90 days. Acceptable for launch since most users haven't signed in yet.
