### PR TITLE
keep the heatmap visible on mobile

### DIFF
--- a/server/src/views/leaderboard.ts
+++ b/server/src/views/leaderboard.ts
@@ -116,6 +116,7 @@ vibe login</pre>
   footer { color: #444; font-size: 11px; margin-top: 20px; padding-top: 16px; border-top: 1px solid #141414; }
   footer .definition { margin-bottom: 8px; }
   footer a { color: #666; }
+  .links a, .links code { white-space: nowrap; }
   @media (max-width: 600px) {
     body { padding: 20px 12px; }
     tbody td, thead th { padding: 12px 4px; }
@@ -166,7 +167,7 @@ vibe login</pre>
   </div>
   <footer>
     <div class="definition"><strong style="color:#777">shipped</strong> = a session with at least one commit and meaningful changes (≥50 lines or ≥3 files).</div>
-    <div class="links"><a href="https://github.com/iamnotstatic/vibetime">github.com/iamnotstatic/vibetime</a> &nbsp;·&nbsp; <code>npm i -g vibetime-cli</code></div>
+    <div class="links"><a href="https://github.com/iamnotstatic/vibetime">github.com/iamnotstatic/vibetime</a> · <code>npm i -g vibetime-cli</code></div>
   </footer>
 </main>
 </body>

--- a/server/src/views/leaderboard.ts
+++ b/server/src/views/leaderboard.ts
@@ -126,7 +126,7 @@ vibe login</pre>
     td.activity, thead th.col-activity { width: 80px; }
     .heatmap { gap: 2px; }
     .heatmap .cell { width: 8px; height: 8px; }
-    td.who a span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    td.who a span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   }
 </style>
 </head>

--- a/server/src/views/leaderboard.ts
+++ b/server/src/views/leaderboard.ts
@@ -120,7 +120,8 @@ vibe login</pre>
     body { padding: 20px 12px; }
     tbody td, thead th { padding: 12px 4px; }
     td.last, thead th.col-last { display: none; }
-    td.shipped, thead th.col-shipped { width: 60px; font-size: 14px; }
+    td.shipped, thead th.col-shipped { width: 60px; }
+    td.shipped { font-size: 14px; }
     td.activity, thead th.col-activity { width: 80px; }
     .heatmap { gap: 2px; }
     .heatmap .cell { width: 8px; height: 8px; }

--- a/server/src/views/leaderboard.ts
+++ b/server/src/views/leaderboard.ts
@@ -117,8 +117,14 @@ vibe login</pre>
   footer .definition { margin-bottom: 8px; }
   footer a { color: #666; }
   @media (max-width: 600px) {
-    td.activity, thead th.col-activity { display: none; }
     body { padding: 20px 12px; }
+    tbody td, thead th { padding: 12px 4px; }
+    td.last, thead th.col-last { display: none; }
+    td.shipped, thead th.col-shipped { width: 60px; font-size: 14px; }
+    td.activity, thead th.col-activity { width: 80px; }
+    .heatmap { gap: 2px; }
+    .heatmap .cell { width: 8px; height: 8px; }
+    td.who a span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary

The previous mobile breakpoint hid the activity column entirely. Most launch-tweet clicks land on phones, so the page's most distinctive visual signature was disappearing for the audience that needed the strongest first impression. Match github's contribution-graph pattern: shrink the cells, don't hide them.

## Changes

- Cells shrunk from 10px to 8px, gap from 3px to 2px (still legible, fits in 80px column).
- Tighter tbody cell padding (8px to 4px horizontal) to free up width.
- `last shipped` column hidden on mobile instead, since the heatmap conveys recency more vividly than a relative timestamp.
- `shipped` column shrunk to 60px with the 14px font we used pre-polish.
- Handle text gets text-overflow ellipsis for very long handles on narrow screens.

Server-only, no CLI release needed. Already deployed to prod (version `b96574a6`).

## Test plan

- [x] `npm run typecheck` clean
- [x] Deployed to prod
- [x] `curl https://vibetime.club/leaderboard` returns the new CSS block
- [ ] Spot-check on an actual phone (or browser devtools at 375px width)