### PR TITLE
leaderboard: attribute ships by ended_at, drain cap-rejected submissions

### DIFF
--- a/server/migrations/0002_ended_at_index.sql
+++ b/server/migrations/0002_ended_at_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_sessions_leaderboard_ended
+  ON sessions(momentum, ended_at, user_github_id);

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "migrate:local": "wrangler d1 migrations apply vibetime --local",
-    "migrate:prod": "wrangler d1 migrations apply vibetime"
+    "migrate:prod": "wrangler d1 migrations apply vibetime --remote"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240620.0",

--- a/server/src/routes/leaderboard.ts
+++ b/server/src/routes/leaderboard.ts
@@ -58,7 +58,7 @@ async function buildData(env: Env, window: Window): Promise<LeaderboardData> {
   const totalsRes = await env.DB.prepare(
     `SELECT COUNT(DISTINCT user_github_id) AS dev_count, COUNT(*) AS session_count
      FROM sessions
-     WHERE momentum = 'shipped' AND started_at > ?`,
+     WHERE momentum = 'shipped' AND ended_at > ?`,
   ).bind(sinceIso).first<{ dev_count: number; session_count: number }>();
   const devCount = totalsRes?.dev_count ?? 0;
   const sessionCount = totalsRes?.session_count ?? 0;
@@ -66,10 +66,10 @@ async function buildData(env: Env, window: Window): Promise<LeaderboardData> {
   const topRes = await env.DB.prepare(
     `SELECT u.github_id, u.handle, u.avatar_url,
             COUNT(*) AS shipped_count,
-            MAX(s.started_at) AS last_shipped_at,
+            MAX(s.ended_at) AS last_shipped_at,
             MIN(s.started_at) AS first_at
      FROM sessions s JOIN users u ON s.user_github_id = u.github_id
-     WHERE s.momentum = 'shipped' AND s.started_at > ?
+     WHERE s.momentum = 'shipped' AND s.ended_at > ?
      GROUP BY u.github_id
      ORDER BY shipped_count DESC, first_at ASC
      LIMIT 100`,
@@ -81,9 +81,9 @@ async function buildData(env: Env, window: Window): Promise<LeaderboardData> {
   const heatmapSince = new Date(Date.now() - HEATMAP_DAYS * 24 * 60 * 60 * 1000).toISOString();
   const placeholders = rows.map(() => '?').join(',');
   const dailyRes = await env.DB.prepare(
-    `SELECT user_github_id, date(started_at) AS day, COUNT(*) AS n
+    `SELECT user_github_id, date(ended_at) AS day, COUNT(*) AS n
      FROM sessions
-     WHERE momentum = 'shipped' AND started_at > ? AND user_github_id IN (${placeholders})
+     WHERE momentum = 'shipped' AND ended_at > ? AND user_github_id IN (${placeholders})
      GROUP BY user_github_id, day`,
   ).bind(heatmapSince, ...rows.map((r) => r.github_id)).all<DailyCount>();
 

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -7,7 +7,7 @@ import { scoreSession } from '../score.js';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const VALID_TIERS = new Set(['shipped', 'progressed', 'tinkering', 'exploring', 'idle', 'interrupted']);
 const VALID_TOOLS_RE = /^[a-z][a-z0-9_-]{0,31}$/i;
-const MAX_AGE_MS = 48 * 60 * 60 * 1000;
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 const MIN_DURATION_S = 60;
 const DAILY_SHIPPED_CAP = 10;
 const SHIPPED_WINDOW_MS = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

Three server-side fixes, no CLI release needed.

### 1. Attribute shipped sessions by end time, not start time

The leaderboard heatmap, window filter, and \`last_shipped_at\` all grouped by \`date(started_at)\`. A claude session that started Monday and worked through Wednesday showed as one dot on Monday with zeros on Tue/Wed, even though most of the actual work happened later.

Switching to \`ended_at\` in \`server/src/routes/leaderboard.ts\` puts the dot on the day work finished, which matches user intuition for when something shipped. \`MIN(started_at) AS first_at\` is kept for tiebreak ordering (platform tenure, not ship recency).

Adds \`idx_sessions_leaderboard_ended\` on \`(momentum, ended_at, user_github_id)\` so the new queries hit a covering index. EXPLAIN QUERY PLAN confirms.

### 2. Extend session age window from 48h to 14d

Sessions bounced by \`DAILY_SHIPPED_CAP\` (429) sit in the CLI's pending queue for retry. The previous 48h \`MAX_AGE_MS\` meant they could age into a 400 \`session too old\` on a later flush, which the CLI treats as drop-forever. 14d lets the rolling 24h cap window drain pending submissions naturally.

### 3. Fix \`migrate:prod\` to target remote D1

\`npm run migrate:prod\` was \`wrangler d1 migrations apply vibetime\` with no \`--remote\` flag, so it silently ran against the local \`.wrangler/state\` copy instead of production. Added \`--remote\`.

## Out of scope (filed for v0.6)

A 3-day session still counts as 1 ship on the leaderboard. The dot is on the right day now, but a marathon session with 100+ commits across multiple days does not light up multiple dots. Per-day ship event model is the structural fix for this; tracked as foundation gap #v0.6.

## Test plan

- [x] \`npm run typecheck\` passes (server)
- [x] Migration applies cleanly against a fresh SQLite DB
- [x] EXPLAIN QUERY PLAN shows the new index is used
- [x] Seeded a fake 3-day session locally and confirmed heatmap puts it on the end day
- [x] Already deployed to production: prod leaderboard.json now reflects the change (5-14 dot visible for affected users)