### PR TITLE
feat: track Claude Code Desktop sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Nothing else to run: Claude Code hot-reloads the settings, so just open a new De
 If you use **both** the terminal wrapper and Desktop hooks, terminal `claude` sessions are counted once, not twice — the hooks stand down when the shell wrapper is already tracking.
 
 > **Why hooks use absolute paths** — the Desktop app, when launched from the Dock, doesn't inherit your shell `PATH`, so a bare `vibe` wouldn't resolve. `vibe hooks install` pins the absolute path to Node and the CLI so tracking works regardless of how Desktop is launched.
+>
+> If you switch Node versions (e.g. an `nvm` upgrade) and remove the old one, re-run `vibe hooks install` so the pinned path points at your current Node.
 
 Stop tracking Desktop at any time:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ Sessions are scored by what happened in git:
 
 **How duration works** — Vibetime polls your git state every 30 seconds. If no file changes, commits, or staging activity are detected for 30 minutes, the idle time is excluded from your session duration. Laptop sleep and background idle are automatically handled. Non-git projects use wall-clock time.
 
+## Claude Code Desktop
+
+`vibe init` wraps the `claude` **terminal** command. The Claude Code **Desktop** app never runs that command, so the shell wrapper can't see it. Track Desktop sessions with hooks instead:
+
+```
+vibe hooks install
+```
+
+This registers session hooks in `~/.claude/settings.json` — the same settings the Desktop app reads. From then on, every Desktop session is recorded and shows up in `vibe status`, `vibe log`, `vibe share`, and the leaderboard, exactly like a terminal session.
+
+Nothing else to run: Claude Code hot-reloads the settings, so just open a new Desktop session. Duration is measured the same way as the terminal — active coding time, with idle gaps over 30 minutes excluded.
+
+If you use **both** the terminal wrapper and Desktop hooks, terminal `claude` sessions are counted once, not twice — the hooks stand down when the shell wrapper is already tracking.
+
+> **Why hooks use absolute paths** — the Desktop app, when launched from the Dock, doesn't inherit your shell `PATH`, so a bare `vibe` wouldn't resolve. `vibe hooks install` pins the absolute path to Node and the CLI so tracking works regardless of how Desktop is launched.
+
+Stop tracking Desktop at any time:
+
+```
+vibe hooks uninstall
+```
+
 ## Leaderboard (opt-in)
 
 Live at **[vibetime.club/leaderboard](https://vibetime.club/leaderboard)**. Public web view, no CLI required to browse.
@@ -116,6 +138,8 @@ vibe leaderboard             shipped sessions, last 7 days
 vibe config show             current settings
 vibe config set handle <name> set your @handle (shown on share cards)
 vibe config add-tool <name>  track a new AI CLI tool
+vibe hooks install           track Claude Code Desktop sessions
+vibe hooks uninstall         stop tracking Claude Code Desktop
 vibe uninstall               remove shell hooks
 ```
 
@@ -125,16 +149,19 @@ Sessions belong to the day they started — a session that runs past midnight ap
 
 ```
 vibe uninstall
+vibe hooks uninstall   # if you tracked Claude Code Desktop
 npm uninstall -g vibetime-cli
 ```
 
-`vibe uninstall` removes all shell hooks from your rc file. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
+`vibe uninstall` removes all shell hooks from your rc file, and `vibe hooks uninstall` removes the Claude Code Desktop hooks from `~/.claude/settings.json`. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
 
 ## Privacy
 
 Vibetime has no telemetry and no account by default. Everything stays on your machine unless you opt in to the leaderboard with `vibe login`.
 
 It reads **git metadata only** — commit counts, line counts, file counts. It never reads file contents, environment variables, API keys, or anything you type into the wrapped tool. The AI CLI's stdin/stdout are passed straight through via `spawn` with `stdio: 'inherit'`.
+
+The Claude Code Desktop hooks are held to the same standard: they read only the session id and working directory from the hook payload — never the transcript, your prompts, or the model's output — and derive the same git metadata from there.
 
 All data is stored locally in `~/.vibe/`. If you've signed in to the leaderboard, see the section above for the exact fields submitted.
 

--- a/src/claude-hooks.ts
+++ b/src/claude-hooks.ts
@@ -1,0 +1,145 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import chalk from 'chalk';
+import { PURPLE } from './colors.js';
+
+const RED = chalk.hex('#EF4444');
+
+const CLAUDE_DIR = join(homedir(), '.claude');
+const SETTINGS_PATH = join(CLAUDE_DIR, 'settings.json');
+
+// Claude Code hook event -> the internal `vibe __hook <event>` we dispatch to.
+// SessionStart opens the session, SessionEnd closes and submits it, and the
+// per-turn events keep the active-time accumulator honest between the two.
+const EVENT_MAP: Record<string, HookEvent> = {
+  SessionStart: 'session-start',
+  UserPromptSubmit: 'activity',
+  PostToolUse: 'activity',
+  Stop: 'activity',
+  SessionEnd: 'session-end',
+};
+
+type HookEvent = 'session-start' | 'activity' | 'session-end';
+
+// Events that match on tool name need a matcher; an empty matcher means "all tools".
+const MATCHER_EVENTS = new Set(['PreToolUse', 'PostToolUse']);
+
+interface HookCommand {
+  type: 'command';
+  command: string;
+  timeout?: number;
+}
+interface HookGroup {
+  matcher?: string;
+  hooks: HookCommand[];
+}
+interface Settings {
+  hooks?: Record<string, HookGroup[]>;
+  [key: string]: unknown;
+}
+
+function shellQuote(p: string): string {
+  return `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
+function vibeCommand(event: HookEvent): string {
+  // The Desktop app launched from the Dock does NOT inherit the shell PATH, so a
+  // bare `vibe` would not resolve. Pin absolute paths to node and cli.js instead.
+  const cli = fileURLToPath(new URL('./cli.js', import.meta.url));
+  return `${shellQuote(process.execPath)} ${shellQuote(cli)} __hook ${event}`;
+}
+
+function isVibeHook(group: HookGroup): boolean {
+  return Array.isArray(group?.hooks) && group.hooks.some(
+    (h) => typeof h?.command === 'string' && h.command.includes('__hook') && h.command.includes('vibe'),
+  );
+}
+
+function readSettings(): Settings | null {
+  if (!existsSync(SETTINGS_PATH)) return {};
+  try {
+    const raw = readFileSync(SETTINGS_PATH, 'utf-8').trim();
+    return raw ? (JSON.parse(raw) as Settings) : {};
+  } catch {
+    return null; // present but unparseable — don't clobber it
+  }
+}
+
+function writeSettings(settings: Settings): void {
+  mkdirSync(CLAUDE_DIR, { recursive: true });
+  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + '\n');
+}
+
+export function installClaudeHooks(): void {
+  const settings = readSettings();
+  if (settings === null) {
+    console.log(`\n  ${RED('✗')} vibe: ${SETTINGS_PATH} is not valid JSON — fix it and re-run\n`);
+    return;
+  }
+
+  const hooks = settings.hooks ?? {};
+  let added = 0;
+  let existing = 0;
+
+  for (const [claudeEvent, vibeEvent] of Object.entries(EVENT_MAP)) {
+    const list = Array.isArray(hooks[claudeEvent]) ? hooks[claudeEvent] : [];
+    if (list.some(isVibeHook)) {
+      existing++;
+      hooks[claudeEvent] = list;
+      continue;
+    }
+    const group: HookGroup = { hooks: [{ type: 'command', command: vibeCommand(vibeEvent), timeout: 10 }] };
+    if (MATCHER_EVENTS.has(claudeEvent)) group.matcher = '';
+    list.push(group);
+    hooks[claudeEvent] = list;
+    added++;
+  }
+
+  settings.hooks = hooks;
+  writeSettings(settings);
+
+  if (added === 0) {
+    console.log(`\n  ${PURPLE('◆')} claude code desktop tracking already installed\n`);
+    return;
+  }
+  console.log(`\n  ${PURPLE('◆')} claude code desktop tracking installed in ${SETTINGS_PATH}\n`);
+  console.log(`  vibe now records a session every time you use Claude Code Desktop.`);
+  console.log(`  settings are hot-reloaded — open a new Claude Code Desktop session to start.\n`);
+  if (existing > 0) console.log(`  (${existing} event${existing === 1 ? '' : 's'} were already wired up)\n`);
+}
+
+export function removeClaudeHooks(): void {
+  const settings = readSettings();
+  if (settings === null) {
+    console.log(`\n  ${RED('✗')} vibe: ${SETTINGS_PATH} is not valid JSON — fix it and re-run\n`);
+    return;
+  }
+  if (!settings.hooks) {
+    console.log(`\n  ${PURPLE('◆')} no claude code desktop hooks found\n`);
+    return;
+  }
+
+  let removed = 0;
+  for (const event of Object.keys(settings.hooks)) {
+    const list = settings.hooks[event];
+    if (!Array.isArray(list)) continue;
+    const kept = list.filter((group) => {
+      const ours = isVibeHook(group);
+      if (ours) removed++;
+      return !ours;
+    });
+    if (kept.length > 0) settings.hooks[event] = kept;
+    else delete settings.hooks[event];
+  }
+  if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+
+  writeSettings(settings);
+
+  if (removed === 0) {
+    console.log(`\n  ${PURPLE('◆')} no claude code desktop hooks found\n`);
+    return;
+  }
+  console.log(`\n  ${PURPLE('◆')} claude code desktop tracking removed from ${SETTINGS_PATH}\n`);
+}

--- a/src/claude-hooks.ts
+++ b/src/claude-hooks.ts
@@ -52,8 +52,12 @@ function vibeCommand(event: HookEvent): string {
 }
 
 function isVibeHook(group: HookGroup): boolean {
+  // `__hook` is our coined subcommand — matching it alone is enough. Don't also
+  // require the literal "vibe" in the path: a dev clone in a differently named
+  // directory has no "vibe" in its cli.js path, which would make reinstall
+  // duplicate our hooks and uninstall miss them.
   return Array.isArray(group?.hooks) && group.hooks.some(
-    (h) => typeof h?.command === 'string' && h.command.includes('__hook') && h.command.includes('vibe'),
+    (h) => typeof h?.command === 'string' && h.command.includes('__hook'),
   );
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,8 @@ import { renderStatus, renderLog, renderLeaderboard } from './render.js';
 import { renderTerminalCard, writeHtmlCard } from './share.js';
 import { wrapTool } from './wrap.js';
 import { initShellHooks, removeShellHooks } from './init.js';
+import { installClaudeHooks, removeClaudeHooks } from './claude-hooks.js';
+import { handleHook } from './hook.js';
 import { login, logout, readAuth } from './auth.js';
 import { fetchLeaderboard } from './leaderboard.js';
 import { flushPendingSubmissions } from './submit.js';
@@ -44,6 +46,20 @@ program
   .command('uninstall')
   .description('remove shell hooks')
   .action(removeShellHooks);
+
+const hooksCmd = program
+  .command('hooks')
+  .description('track Claude Code Desktop via session hooks');
+
+hooksCmd
+  .command('install')
+  .description('track Claude Code Desktop sessions (no shell wrapper needed)')
+  .action(installClaudeHooks);
+
+hooksCmd
+  .command('uninstall')
+  .description('stop tracking Claude Code Desktop sessions')
+  .action(removeClaudeHooks);
 
 program
   .command('status')
@@ -215,5 +231,32 @@ program
   .action(async (tool: string, args: string[]) => {
     await wrapTool(tool, args);
   });
+
+// Invoked by Claude Code hooks with the event payload on stdin. Must stay silent
+// on stdout (SessionStart stdout is fed to the model) and always exit cleanly so
+// it can never interfere with the user's session.
+program
+  .command('__hook', { hidden: true })
+  .argument('<event>', 'session-start | activity | session-end')
+  .helpOption(false)
+  .action(async (event: string) => {
+    try {
+      await handleHook(event, await readStdin());
+    } catch {}
+    process.exit(0);
+  });
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) return resolve('');
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => (data += chunk));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(data));
+    // never hang a session waiting on stdin
+    setTimeout(() => resolve(data), 2000).unref();
+  });
+}
 
 program.parse();

--- a/src/db.ts
+++ b/src/db.ts
@@ -19,6 +19,10 @@ export interface Session {
   exitCode: number;
   lastActivityAt?: string;
   submittedAt?: string;
+  // HEAD sha when the session started. Hook-tracked sessions (Claude Code Desktop)
+  // record start and end in separate processes, so the baseline sha is persisted
+  // here rather than held in memory like the shell-wrapped flow.
+  startSha?: string;
 }
 
 interface DbSchema {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,0 +1,142 @@
+import { addSession, updateSession, getSessions, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
+import { isGitRepo, getHeadSha, getBranch, getProjectName, getDiffStats, type GitDiffStats } from './git.js';
+import { readConfig } from './config.js';
+import { scoreSession } from './score.js';
+import { flushPendingSubmissions } from './submit.js';
+
+// Claude Code delivers a JSON payload on stdin to every hook command. We read
+// only the fields below — never the transcript contents — so hook-tracked
+// sessions stay within vibetime's "git metadata only" privacy model.
+interface HookInput {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  source?: string; // SessionStart: startup | resume | clear | compact
+  reason?: string; // SessionEnd: clear | logout | prompt_input_exit | other
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Skip a git diff on rapid-fire activity events (e.g. bursts of parallel tool
+// calls); duration still accumulates, only the git stats refresh is throttled.
+const GIT_REFRESH_MS = 15_000;
+
+type HookEvent = 'session-start' | 'activity' | 'session-end';
+
+const EMPTY_STATS: GitDiffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
+
+// Active time since the last activity mark, capped at the inactivity timeout so
+// idle gaps beyond the threshold are excluded — mirrors the poller in wrap.ts.
+function activeSecondsSince(lastActivityAt: string | undefined, startedAt: string, now: number): number {
+  const lastMs = new Date(lastActivityAt || startedAt).getTime();
+  const gap = Math.max(now - lastMs, 0);
+  return Math.round(Math.min(gap, INACTIVITY_TIMEOUT_MS) / 1000);
+}
+
+function diffFor(session: Session, cwd: string): GitDiffStats {
+  if (!session.startSha || !isGitRepo(cwd)) return EMPTY_STATS;
+  return getDiffStats(session.startSha, getHeadSha(cwd), cwd);
+}
+
+export async function handleHook(event: string, raw: string): Promise<void> {
+  // The shell wrapper (`vibe __wrap`) already tracks its child session end to
+  // end and marks it with VIBE_SESSION=1. Claude Code fires these hooks inside
+  // that wrapped process too, so bail out to avoid double-counting.
+  if (process.env.VIBE_SESSION === '1') return;
+
+  let input: HookInput;
+  try {
+    input = raw ? JSON.parse(raw) : {};
+  } catch {
+    return;
+  }
+
+  const sessionId = input.session_id;
+  if (!sessionId || !UUID_RE.test(sessionId)) return;
+  const cwd = input.cwd || process.cwd();
+
+  switch (event as HookEvent) {
+    case 'session-start':
+      return onSessionStart(sessionId, cwd);
+    case 'activity':
+      return onActivity(sessionId, cwd);
+    case 'session-end':
+      return onSessionEnd(sessionId, cwd);
+  }
+}
+
+async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
+  await reapOrphanedSessions();
+
+  // SessionStart also fires on resume/clear/compact — key off the Claude
+  // session id so a session is only opened once.
+  if (getSessions().some((s) => s.id === sessionId)) return;
+
+  const hasGit = isGitRepo(cwd);
+  const startedAt = new Date().toISOString();
+  const config = readConfig();
+
+  const session: Session = {
+    id: sessionId,
+    tool: 'claude',
+    project: hasGit ? getProjectName(cwd) : cwd.split('/').pop() || 'unknown',
+    branch: hasGit ? getBranch(cwd) : 'unknown',
+    startedAt,
+    endedAt: startedAt,
+    durationSeconds: 0,
+    ...EMPTY_STATS,
+    momentum: scoreSession({ ...EMPTY_STATS, exitCode: -1 }, config),
+    exitCode: -1,
+    lastActivityAt: startedAt,
+    startSha: hasGit ? getHeadSha(cwd) : '',
+  };
+
+  try {
+    await addSession(session);
+  } catch {}
+}
+
+async function onActivity(sessionId: string, cwd: string): Promise<void> {
+  const session = getSessions().find((s) => s.id === sessionId);
+  if (!session || session.exitCode !== -1) return; // only live sessions
+
+  const now = Date.now();
+  const lastMs = new Date(session.lastActivityAt || session.startedAt).getTime();
+  const gap = Math.max(now - lastMs, 0);
+
+  const updates: Partial<Session> = {
+    durationSeconds: session.durationSeconds + activeSecondsSince(session.lastActivityAt, session.startedAt, now),
+    lastActivityAt: new Date(now).toISOString(),
+  };
+
+  if (gap >= GIT_REFRESH_MS) {
+    const stats = diffFor(session, cwd);
+    Object.assign(updates, stats);
+    updates.momentum = scoreSession({ ...stats, exitCode: -1 }, readConfig());
+  }
+
+  try {
+    await updateSession(sessionId, updates);
+  } catch {}
+}
+
+async function onSessionEnd(sessionId: string, cwd: string): Promise<void> {
+  const session = getSessions().find((s) => s.id === sessionId);
+  if (!session || session.exitCode !== -1) return; // unknown or already finalized
+
+  const now = Date.now();
+  const stats = diffFor(session, cwd);
+
+  try {
+    await updateSession(sessionId, {
+      endedAt: new Date(now).toISOString(),
+      durationSeconds: session.durationSeconds + activeSecondsSince(session.lastActivityAt, session.startedAt, now),
+      ...stats,
+      momentum: scoreSession({ ...stats, exitCode: 0 }, readConfig()),
+      exitCode: 0,
+      lastActivityAt: new Date(now).toISOString(),
+    });
+  } catch {}
+
+  await flushPendingSubmissions(1500).catch(() => {});
+}

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -38,6 +38,19 @@ function diffFor(session: Session, cwd: string): GitDiffStats {
   return getDiffStats(session.startSha, getHeadSha(cwd), cwd);
 }
 
+// The shared reaper (reapOrphanedSessions) finalizes any idle in-progress
+// session as `interrupted` after 30 minutes — it runs on every vibe status/log/
+// share and inside onSessionStart. Terminal sessions survive it because their
+// poller rewrites the row every 30s; a hook session only writes on hook events,
+// so a Desktop session idle over a lunch break gets reaped mid-flight. When the
+// user comes back and ships, we must reopen it — otherwise the later activity
+// and session-end events bail on the `exitCode !== -1` guard and the session is
+// frozen as interrupted with the work lost. A normally-ended hook session has
+// exitCode 0 and never scores `interrupted`, so this only matches the reaper.
+function wasReapedInterrupted(session: Session): boolean {
+  return session.exitCode !== -1 && session.momentum === 'interrupted';
+}
+
 export async function handleHook(event: string, raw: string): Promise<void> {
   // The shell wrapper (`vibe __wrap`) already tracks its child session end to
   // end and marks it with VIBE_SESSION=1. Claude Code fires these hooks inside
@@ -98,18 +111,32 @@ async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
 
 async function onActivity(sessionId: string, cwd: string): Promise<void> {
   const session = getSessions().find((s) => s.id === sessionId);
-  if (!session || session.exitCode !== -1) return; // only live sessions
+  if (!session) return;
+
+  const reopening = wasReapedInterrupted(session);
+  if (session.exitCode !== -1 && !reopening) return; // finalized normally — ignore late events
 
   const now = Date.now();
   const lastMs = new Date(session.lastActivityAt || session.startedAt).getTime();
   const gap = Math.max(now - lastMs, 0);
 
   const updates: Partial<Session> = {
-    durationSeconds: session.durationSeconds + activeSecondsSince(session.lastActivityAt, session.startedAt, now),
+    // On reopen, restart the active-time clock from now so the idle gap that
+    // tripped the reaper isn't counted; the reaper already capped the duration.
+    durationSeconds: session.durationSeconds + (reopening ? 0 : activeSecondsSince(session.lastActivityAt, session.startedAt, now)),
     lastActivityAt: new Date(now).toISOString(),
   };
 
-  if (gap >= GIT_REFRESH_MS) {
+  if (reopening) {
+    // Bring the session back to live and clear the interrupted submission so the
+    // corrected final state resubmits — the server upserts on id, so it's safe.
+    updates.exitCode = -1;
+    updates.submittedAt = undefined;
+  }
+
+  // Refresh git stats on reopen (to recover work shipped before the reap) and
+  // otherwise only past the throttle window.
+  if (reopening || gap >= GIT_REFRESH_MS) {
     const stats = diffFor(session, cwd);
     Object.assign(updates, stats);
     updates.momentum = scoreSession({ ...stats, exitCode: -1 }, readConfig());
@@ -122,7 +149,10 @@ async function onActivity(sessionId: string, cwd: string): Promise<void> {
 
 async function onSessionEnd(sessionId: string, cwd: string): Promise<void> {
   const session = getSessions().find((s) => s.id === sessionId);
-  if (!session || session.exitCode !== -1) return; // unknown or already finalized
+  if (!session) return;
+
+  const reopening = wasReapedInterrupted(session);
+  if (session.exitCode !== -1 && !reopening) return; // unknown or already finalized normally
 
   const now = Date.now();
   const stats = diffFor(session, cwd);
@@ -130,11 +160,15 @@ async function onSessionEnd(sessionId: string, cwd: string): Promise<void> {
   try {
     await updateSession(sessionId, {
       endedAt: new Date(now).toISOString(),
-      durationSeconds: session.durationSeconds + activeSecondsSince(session.lastActivityAt, session.startedAt, now),
+      // Reopened sessions restart the clock from now (see onActivity); the reaper
+      // already capped their duration.
+      durationSeconds: session.durationSeconds + (reopening ? 0 : activeSecondsSince(session.lastActivityAt, session.startedAt, now)),
       ...stats,
       momentum: scoreSession({ ...stats, exitCode: 0 }, readConfig()),
       exitCode: 0,
       lastActivityAt: new Date(now).toISOString(),
+      // Clear any interrupted submission so the corrected final state resubmits.
+      submittedAt: undefined,
     });
   } catch {}
 


### PR DESCRIPTION
## Track Claude Code Desktop sessions

### Problem

`vibe init` wraps the `claude` **terminal** command via shell hooks, so a session is only tracked when you launch `claude` from a shell. The Claude Code **Desktop** app never invokes that command, so `vibe __wrap` never fires and Desktop work is invisible to vibetime. For people who work mostly in Desktop, none of their time is tracked.

### Approach

Track Desktop the way Claude Code exposes itself to tooling: **session hooks**. `vibe hooks install` registers hooks in `~/.claude/settings.json` (the same settings the Desktop app reads) that call a hidden `vibe __hook <event>` on each session lifecycle event:

| Claude hook | vibe action |
|---|---|
| `SessionStart` | open a session (record start, HEAD sha, project, branch) |
| `UserPromptSubmit` / `PostToolUse` / `Stop` | mark activity, accumulate active time, refresh git stats |
| `SessionEnd` | finalize duration + git diff, score momentum, submit to the leaderboard |

Desktop sessions land in the same `~/.vibe/sessions.json` with `tool: "claude"`, so they show up in `vibe status`, `vibe log`, `vibe share`, and the leaderboard exactly like terminal sessions. **No server changes** — the payload is unchanged and the Claude `session_id` is already a UUID the API accepts.

### Duration + idle

Active time is accumulated across hook events and each idle gap is capped at the 30-minute inactivity timeout — the same idle-exclusion rule the terminal poller uses, so Desktop and terminal durations are comparable. A single git baseline sha is persisted on the session (`startSha`) because start and end now happen in separate processes.

### Notes / decisions

- **No double-counting.** Claude Code fires these hooks inside a shell-wrapped `claude` too. The handler short-circuits when `VIBE_SESSION=1`, so if you run both `vibe init` and `vibe hooks install`, terminal sessions are counted once.
- **Absolute paths.** The Desktop app launched from the Dock does not inherit the shell `PATH`, so a bare `vibe` would not resolve. `vibe hooks install` pins absolute paths to Node and `cli.js`.
- **Privacy preserved.** Hooks read only `session_id` and `cwd` from the payload — never the transcript, prompts, or model output — and derive the same git metadata as the wrapper. Updated the Privacy section to say so.
- **Safe settings merge.** Install merges into existing `~/.claude/settings.json` without touching other keys or the user's own hooks, is idempotent, and refuses to write if the file is not valid JSON. `vibe hooks uninstall` removes only vibe's hook entries.
- **Silent + safe hooks.** `vibe __hook` writes nothing to stdout (SessionStart stdout is fed to the model), swallows all errors, and always exits 0, so it can never disrupt a session.

### Testing

Verified end-to-end against a throwaway `$HOME` and a real git repo: install/merge/idempotency/uninstall, session-start → activity → session-end lifecycle, git-diff scoring, idle-gap capping, the `VIBE_SESSION` dedup, non-UUID/empty-stdin/unknown-id/non-git edge cases. `tsc` clean.

### Usage

```
vibe hooks install     # open a new Desktop session; it is now tracked
vibe hooks uninstall   # stop tracking Desktop
```
