### PR TITLE
fix: honour VIBE_SESSION only while the wrapper that set it is alive

### DIFF
--- a/.claude/skills/senior-engineer/SKILL.md
+++ b/.claude/skills/senior-engineer/SKILL.md
@@ -14,7 +14,7 @@ You never add dependencies without justification. You never put display logic ou
 ## Known limitations
 
 - Fish shell not supported — `vibe init` writes bash/zsh function syntax. Fish users must add the hook manually: `function claude; vibe __wrap claude $argv; end` (issue #1)
-- `VIBE_SESSION=1` inherited by child processes that call claude programmatically — known tradeoff of the nesting guard. A tool that spawns `claude` as a subprocess will skip tracking for that inner invocation.
+- `VIBE_SESSION` inherited by child processes that call claude programmatically — known tradeoff of the nesting guard. A tool that spawns `claude` as a subprocess will skip tracking for that inner invocation. The marker holds the wrapper's pid and is only honoured while that pid is alive (`src/session-flag.ts`), so a copy stranded in a long-lived ancestor no longer disables tracking permanently. A recycled pid can still cost one launch, which self-corrects.
 
 ## Foundation work in progress
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -3,6 +3,7 @@ import { isGitRepo, getHeadSha, getBranch, getProjectName, getDiffStats, type Gi
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { flushPendingSubmissions } from './submit.js';
+import { isInsideLiveSession } from './session-flag.js';
 
 // Claude Code delivers a JSON payload on stdin to every hook command. We read
 // only the fields below — never the transcript contents — so hook-tracked
@@ -53,9 +54,11 @@ function wasReapedInterrupted(session: Session): boolean {
 
 export async function handleHook(event: string, raw: string): Promise<void> {
   // The shell wrapper (`vibe __wrap`) already tracks its child session end to
-  // end and marks it with VIBE_SESSION=1. Claude Code fires these hooks inside
-  // that wrapped process too, so bail out to avoid double-counting.
-  if (process.env.VIBE_SESSION === '1') return;
+  // end and marks the environment it spawns. Claude Code fires these hooks inside
+  // that wrapped process too, so bail out to avoid double-counting — but only
+  // while that wrapper is actually running, or a stale marker would silence this
+  // path as well and leave the session untracked by either mechanism.
+  if (isInsideLiveSession()) return;
 
   let input: HookInput;
   try {

--- a/src/session-flag.ts
+++ b/src/session-flag.ts
@@ -1,0 +1,56 @@
+// The nesting guard. `vibe __wrap` stamps this variable on the tool it spawns so
+// that a second wrapper started inside that session — and the Claude Code hooks,
+// which fire inside the wrapped process — know the work is already being tracked
+// and stay out of the way.
+const VAR = 'VIBE_SESSION';
+
+/**
+ * Environment for a wrapped child, marked with this wrapper's pid.
+ *
+ * The pid is what makes the marker falsifiable. Any long-lived ancestor can end
+ * up holding this variable forever — a Terminal.app relaunched from inside a
+ * session, a tmux server, a desktop app started from a wrapped shell — and every
+ * shell it spawns inherits it. A bare "1" is indistinguishable from real nesting,
+ * so tracking stays silently off for the entire life of that process. A pid can
+ * be checked against the process table.
+ */
+export function sessionEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, [VAR]: String(process.pid) };
+}
+
+/**
+ * True when this process is running inside a `vibe __wrap` session that is still
+ * alive — the only case where skipping tracking is correct.
+ *
+ * A marker left behind by a wrapper that has since exited is stale and ignored,
+ * so tracking recovers on its own instead of needing the stranded ancestor to be
+ * killed.
+ */
+export function isInsideLiveSession(): boolean {
+  const marker = process.env[VAR];
+  if (!marker) return false;
+
+  const pid = Number(marker);
+  // Wrappers before this change wrote a literal "1", which carries no liveness
+  // information — and 1 is always a live pid (init/launchd), so honouring it
+  // would leave the stale-marker case unrecoverable. Treat it as stale: the cost
+  // is at most one duplicate session while an old wrapper is still open during an
+  // upgrade, against tracking that otherwise never comes back.
+  if (!Number.isInteger(pid) || pid <= 1) return false;
+
+  return isAlive(pid);
+}
+
+function isAlive(pid: number): boolean {
+  // A recycled pid can still read as live, which skips tracking for that one
+  // launch. That is self-correcting — the next launch draws a different pid —
+  // unlike the stale marker it replaces, which never cleared.
+  try {
+    // Signal 0 runs the existence and permission checks without delivering.
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means the process exists but belongs to another user — still alive.
+    return (e as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -7,6 +7,7 @@ import { scoreSession } from './score.js';
 import { renderEndcard } from './render.js';
 import { flushPendingSubmissions, submitInProgress } from './submit.js';
 import { getRecommendedVersion } from './api.js';
+import { isInsideLiveSession, sessionEnv } from './session-flag.js';
 import { PURPLE } from './colors.js';
 
 const POLL_INTERVAL_MS = 30_000;
@@ -21,7 +22,7 @@ function reportSpawnError(tool: string, err: NodeJS.ErrnoException): void {
 }
 
 export async function wrapTool(tool: string, args: string[]): Promise<void> {
-  if (process.env.VIBE_SESSION === '1') {
+  if (isInsideLiveSession()) {
     const child = spawn(tool, args, { stdio: 'inherit' });
     child.on('error', (err: NodeJS.ErrnoException) => {
       reportSpawnError(tool, err);
@@ -152,7 +153,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
 
   const child = spawn(tool, args, {
     stdio: 'inherit',
-    env: { ...process.env, VIBE_SESSION: '1' },
+    env: sessionEnv(),
   });
 
   // signal handling — registered after spawn so child is defined


### PR DESCRIPTION
## The problem

`vibe` can stop recording sessions entirely, with no error, and stay that way indefinitely.

The nesting guard writes a literal `VIBE_SESSION=1` into the environment of the tool it spawns, and both readers test for that exact string. The value says *some* session existed — not which one, and not whether it still does. So any process that captures the variable keeps reading as "already tracked" for the rest of its life.

The common way to end up there: relaunch Terminal.app from inside a wrapped session. The app inherits `VIBE_SESSION=1` into its own environment, and from then on every shell, tab and window it spawns inherits it too. Both tracking paths gate on the same string:

- `src/wrap.ts` takes its passthrough branch and records nothing
- `src/hook.ts` returns early to avoid double-counting the wrapper

which means the Claude Code Desktop hooks added in #14 — the fallback — go quiet for the same reason. Neither path prints anything, so the CLI looks completely normal: Claude launches, the session runs, and no endcard appears at the end. Nothing prompts the user to kill the stranded process, because nothing indicates anything is wrong.

I hit this on my own machine. Terminal.app had been running since a relaunch on Jul 23; `~/.vibe/sessions.json` had not been written since **the same minute**, and three live `claude` sessions were being tracked by neither path. Eleven days of sessions lost. Everything else checked out — hooks present in `.zshrc`, `claude` resolving to the function, `~/.vibe` writable, disk free, no DB corruption. Running the wrapper with the variable stripped tracked a session immediately.

### Reproduce

```sh
VIBE_SESSION=1 vibe __wrap claude    # runs normally, records nothing, forever
```

## The fix

Stamp the wrapper's **pid** instead of `1`, and honour the marker only while that pid is still in the process table. A pid is a claim that can be checked; `1` is not.

New `src/session-flag.ts` holds the two halves, and the three touchpoints in `wrap.ts` / `hook.ts` route through it:

```ts
export function sessionEnv(): NodeJS.ProcessEnv {
  return { ...process.env, [VAR]: String(process.pid) };
}

export function isInsideLiveSession(): boolean {
  const marker = process.env[VAR];
  if (!marker) return false;
  const pid = Number(marker);
  if (!Number.isInteger(pid) || pid <= 1) return false;
  return isAlive(pid);
}
```

`isAlive` uses `process.kill(pid, 0)` — signal 0 runs the kernel's existence and permission checks without delivering anything. `EPERM` counts as alive (the process exists, it just belongs to another user); `ESRCH` means it's gone.

| `VIBE_SESSION` | Verdict | Behavior |
| --- | --- | --- |
| unset | not nested | track |
| pid of a running wrapper | genuinely nested | skip, defer to the outer wrapper |
| pid of an exited wrapper | stale | track |
| `1` (pre-existing installs) | stale | track |
| non-numeric | stale | track |

Real nesting is unaffected: the outer wrapper is running when the inner one checks, so the inner one still stands down.

## Judgment calls worth reviewing

**Legacy `1` is treated as stale.** It carries no liveness information, and 1 is always a live pid (init/launchd), so honouring it would leave exactly this failure unrecoverable for everyone already in the broken state. The cost is at most one duplicate session while an old wrapper is still open mid-upgrade. Happy to flip this if you'd rather protect the upgrade window.

**Recycled pids can still cost one launch.** If the OS reuses a dead wrapper's pid for an unrelated process, that launch reads as live and skips. It self-corrects on the next launch, since a new wrapper draws a new pid — a bounded, transient miss replacing an unbounded permanent one. Verifying ancestry instead would mean walking the process tree via `ps` on every launch, which felt like the wrong trade for the remaining risk. Noted in the code comment.

**New module rather than inlining.** Two independent readers plus one writer, and the logic is non-obvious enough to want the comments in one place.

## Testing

`npm run build` — zero errors. Smoke tests ran against a throwaway `HOME`:

```
  wrapper guard (vibe __wrap)
  PASS  no marker (normal launch)                      recorded=1
  PASS  stale legacy marker VIBE_SESSION=1             recorded=1
  PASS  stale marker, dead pid                         recorded=1
  PASS  garbage marker                                 recorded=1
  PASS  live marker (real nesting)                     recorded=0

  real nesting end-to-end (outer wrapper spawns inner)
  PASS  outer tracked, inner skipped                   recorded=1

  desktop hook guard (vibe __hook)
  PASS  no marker -> hook tracks                       recorded=1
  PASS  stale marker -> hook tracks                    recorded=1
  PASS  live marker -> hook defers to wrapper          recorded=0
```

The same stale-marker case records **0** sessions on the released build and **1** on this branch, so the test discriminates rather than passing vacuously. `vibe status`, `vibe log` and the endcard all render unchanged.

## Notes

- `.claude/skills/senior-engineer/SKILL.md` listed this as a known tradeoff of the nesting guard. That entry described a tool spawning `claude` as a subprocess, where the guard is doing its job — a marker stranded in a long-lived ancestor isn't nesting at all. Updated to describe the pid-liveness behavior and the residual recycled-pid case.
- No version bump — that's a maintainer call at release time.
- Unrelated, noticed while installing: the committed `package-lock.json` says `0.1.5` while `package.json` says `0.5.0`. Left alone to keep this diff focused, but it's worth a separate sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
