### PR TITLE
fix: score sessions started from a directory of repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This registers session hooks in `~/.claude/settings.json` — the same settings 
 
 Nothing else to run: Claude Code hot-reloads the settings, so just open a new Desktop session. Duration is measured the same way as the terminal — active coding time, with idle gaps over 30 minutes excluded.
 
+**Working across several repos?** Start the session wherever you like. If that directory isn't a repo itself, vibetime picks up the repos sitting directly inside it and measures all of them, so a session that touches `api/` and `web/` is scored on both. A directory with no repos in or under it isn't tracked — there'd be nothing to measure.
+
 If you use **both** the terminal wrapper and Desktop hooks, terminal `claude` sessions are counted once, not twice — the hooks stand down when the shell wrapper is already tracking.
 
 > **Why hooks use absolute paths** — the Desktop app, when launched from the Dock, doesn't inherit your shell `PATH`, so a bare `vibe` wouldn't resolve. `vibe hooks install` pins the absolute path to Node and the CLI so tracking works regardless of how Desktop is launched.

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { readFileSync, writeFileSync, renameSync, mkdirSync, rmdirSync, unlinkSync, statSync, existsSync } from 'node:fs';
 import { VIBE_DIR, ensureVibeDir } from './config.js';
 import type { MomentumTier } from './score.js';
+import type { RepoBaseline } from './git.js';
 
 export interface Session {
   id: string;
@@ -22,7 +23,15 @@ export interface Session {
   // HEAD sha when the session started. Hook-tracked sessions (Claude Code Desktop)
   // record start and end in separate processes, so the baseline sha is persisted
   // here rather than held in memory like the shell-wrapped flow.
+  //
+  // Superseded by `repos`, which carries a baseline per repo. Still written, and
+  // still read as a fallback, so sessions recorded by an older CLI keep scoring
+  // correctly across an upgrade.
   startSha?: string;
+  // Every repo the session watches, each with its baseline HEAD: one entry for a
+  // session started inside a repo, several for one started from a directory that
+  // holds repos side by side.
+  repos?: RepoBaseline[];
 }
 
 interface DbSchema {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,9 +1,16 @@
 import { execSync } from 'node:child_process';
-import { basename } from 'node:path';
+import { existsSync, readdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
 
 const SHA_RE = /^[0-9a-f]{4,40}$/;
 
 const GIT_TIMEOUT_MS = 3_000;
+
+// Bounds for the one-level repo scan below. A container directory with more
+// entries than this is almost certainly not a project root, and tracking every
+// repo under it would cost a git spawn each on every refresh.
+const MAX_SCANNED_ENTRIES = 100;
+const MAX_DISCOVERED_REPOS = 10;
 
 function run(cmd: string, cwd?: string) {
   try {
@@ -41,6 +48,64 @@ export function getProjectName(cwd?: string): string {
   return basename(cwd || process.cwd());
 }
 
+export function getRepoRoot(cwd?: string): string {
+  return run('git rev-parse --show-toplevel', cwd);
+}
+
+// A repo a session watches, paired with the HEAD it had when the session opened.
+export interface RepoBaseline {
+  path: string;
+  startSha: string;
+}
+
+// The repos a session should measure. Usually that's the one repo the session
+// started inside. But a session is just as often started from a directory that
+// holds several repos side by side — a monorepo-ish parent like ~/work/acme with
+// `api/` and `web/` in it, or a plain ~/dev. That directory has no HEAD of its
+// own, so measuring only `cwd` scores every such session as idle no matter how
+// much shipped. So: fall back to the repos one level down.
+//
+// Discovery is a filesystem check rather than a git spawn per child, and never
+// recurses past one level, so it stays cheap enough to run inside a hook.
+export function discoverRepos(cwd: string): string[] {
+  const root = getRepoRoot(cwd);
+  if (root) return [root];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(cwd, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith('.') && e.name !== 'node_modules')
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+
+  const repos: string[] = [];
+  for (const name of entries.slice(0, MAX_SCANNED_ENTRIES)) {
+    if (repos.length >= MAX_DISCOVERED_REPOS) break;
+    const child = join(cwd, name);
+    // `.git` is a directory in a normal clone and a file in a worktree or
+    // submodule — existsSync covers both.
+    if (existsSync(join(child, '.git'))) repos.push(child);
+  }
+  return repos;
+}
+
+export function baselineRepos(cwd: string): RepoBaseline[] {
+  return discoverRepos(cwd).map((path) => ({ path, startSha: getHeadSha(path) }));
+}
+
+// How a session labels itself. One repo reads as that repo on whatever branch it
+// is on; several read as the directory holding them, since no single branch
+// describes the work.
+export function describeRepos(repos: RepoBaseline[], cwd: string): { project: string; branch: string } {
+  if (repos.length === 1) {
+    return { project: getProjectName(repos[0].path), branch: getBranch(repos[0].path) };
+  }
+  return { project: basename(cwd) || 'unknown', branch: 'multiple' };
+}
+
 export interface GitDiffStats {
   commits: number;
   linesAdded: number;
@@ -65,6 +130,10 @@ function parseNumstat(numstat: string) {
 
 export function getWorkingTreeFingerprint(cwd?: string): string {
   return run('git status --porcelain', cwd);
+}
+
+export function getReposFingerprint(repos: RepoBaseline[]): string {
+  return repos.map((r) => `${r.path}\n${getWorkingTreeFingerprint(r.path)}`).join('\n');
 }
 
 export function getDiffStats(fromSha: string, toSha: string, cwd?: string): GitDiffStats {
@@ -92,4 +161,19 @@ export function getDiffStats(fromSha: string, toSha: string, cwd?: string): GitD
   for (const f of uncommitted.files) allFiles.add(f);
 
   return { commits, linesAdded, linesRemoved, filesTouched: allFiles.size };
+}
+
+// Stats for every repo the session watches, summed. Files are counted per repo
+// and added up — two repos can hold the same relative path without it being the
+// same file, so there is nothing to de-duplicate across them.
+export function getReposDiffStats(repos: RepoBaseline[]): GitDiffStats {
+  const total: GitDiffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
+  for (const repo of repos) {
+    const stats = getDiffStats(repo.startSha, getHeadSha(repo.path), repo.path);
+    total.commits += stats.commits;
+    total.linesAdded += stats.linesAdded;
+    total.linesRemoved += stats.linesRemoved;
+    total.filesTouched += stats.filesTouched;
+  }
+  return total;
 }

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,5 +1,5 @@
 import { addSession, updateSession, getSessions, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
-import { isGitRepo, getHeadSha, getBranch, getProjectName, getDiffStats, type GitDiffStats } from './git.js';
+import { isGitRepo, getHeadSha, getDiffStats, getReposDiffStats, baselineRepos, describeRepos, type GitDiffStats } from './git.js';
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { flushPendingSubmissions } from './submit.js';
@@ -34,6 +34,9 @@ function activeSecondsSince(lastActivityAt: string | undefined, startedAt: strin
 }
 
 function diffFor(session: Session, cwd: string): GitDiffStats {
+  if (session.repos?.length) return getReposDiffStats(session.repos);
+  // Fallback for sessions opened by an older CLI, which recorded a single
+  // baseline sha against the session cwd.
   if (!session.startSha || !isGitRepo(cwd)) return EMPTY_STATS;
   return getDiffStats(session.startSha, getHeadSha(cwd), cwd);
 }
@@ -85,15 +88,21 @@ async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
   // session id so a session is only opened once.
   if (getSessions().some((s) => s.id === sessionId)) return;
 
-  const hasGit = isGitRepo(cwd);
+  // The repo the session started in, or — when it started from a directory that
+  // holds repos rather than being one — the repos inside it. Desktop fires
+  // SessionStart for every session, including quick questions asked from a
+  // directory with no code under it at all; those can never score, so skip them
+  // instead of piling up idle rows in `vibe log`.
+  const repos = baselineRepos(cwd);
+  if (repos.length === 0) return;
+
   const startedAt = new Date().toISOString();
   const config = readConfig();
 
   const session: Session = {
     id: sessionId,
     tool: 'claude',
-    project: hasGit ? getProjectName(cwd) : cwd.split('/').pop() || 'unknown',
-    branch: hasGit ? getBranch(cwd) : 'unknown',
+    ...describeRepos(repos, cwd),
     startedAt,
     endedAt: startedAt,
     durationSeconds: 0,
@@ -101,7 +110,8 @@ async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
     momentum: scoreSession({ ...EMPTY_STATS, exitCode: -1 }, config),
     exitCode: -1,
     lastActivityAt: startedAt,
-    startSha: hasGit ? getHeadSha(cwd) : '',
+    startSha: repos.length === 1 ? repos[0].startSha : '',
+    repos,
   };
 
   try {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { addSession, updateSession, deleteSession, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
-import { isGitRepo, getHeadSha, getBranch, getProjectName, getDiffStats, getWorkingTreeFingerprint } from './git.js';
+import { baselineRepos, describeRepos, getReposDiffStats, getReposFingerprint } from './git.js';
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { renderEndcard } from './render.js';
@@ -33,10 +33,14 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
 
   const cwd = process.cwd();
   const startedAt = new Date().toISOString();
-  const hasGit = isGitRepo(cwd);
-  const startSha = hasGit ? getHeadSha(cwd) : '';
-  const branch = hasGit ? getBranch(cwd) : 'unknown';
-  const project = hasGit ? getProjectName(cwd) : cwd.split('/').pop() || 'unknown';
+  // The repo this was launched in, or the repos inside the directory it was
+  // launched from. Unlike the Desktop hooks, the wrapper still tracks a
+  // directory with no repos at all by wall clock — you invoked it deliberately.
+  const repos = baselineRepos(cwd);
+  const hasGit = repos.length > 0;
+  const { project, branch } = hasGit
+    ? describeRepos(repos, cwd)
+    : { project: cwd.split('/').pop() || 'unknown', branch: 'unknown' };
   const config = readConfig();
   const sessionId = randomUUID();
   let lastActivityAt = startedAt;
@@ -54,8 +58,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
 
     let diffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
     if (hasGit) {
-      const endSha = getHeadSha(cwd);
-      diffStats = getDiffStats(startSha, endSha, cwd);
+      diffStats = getReposDiffStats(repos);
     }
     const momentum = scoreSession({ ...diffStats, exitCode }, config);
     return { endedAt, durationSeconds, ...diffStats, momentum, exitCode, lastActivityAt };
@@ -66,6 +69,8 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
   const session: Session = {
     id: sessionId, tool, project, branch, startedAt,
     ...initial,
+    startSha: repos.length === 1 ? repos[0].startSha : '',
+    repos,
   };
   try { await addSession(session); } catch (e) {
     console.error(`  vibe: failed to save session — ${e instanceof Error ? e.message : 'unknown error'}`);
@@ -75,7 +80,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
   let prevCommits = initial.commits;
   let prevLinesAdded = initial.linesAdded;
   let prevLinesRemoved = initial.linesRemoved;
-  let prevTreeState = hasGit ? getWorkingTreeFingerprint(cwd) : '';
+  let prevTreeState = hasGit ? getReposFingerprint(repos) : '';
   let lastInProgressSubmitAt = 0;
   const poll = setInterval(async () => {
     try {
@@ -88,7 +93,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
       }
 
       const snap = snapshot(-1);
-      const treeState = hasGit ? getWorkingTreeFingerprint(cwd) : '';
+      const treeState = hasGit ? getReposFingerprint(repos) : '';
       const treeChanged = treeState !== prevTreeState;
       const hasNewActivity = snap.commits > prevCommits || snap.linesAdded > prevLinesAdded || snap.linesRemoved > prevLinesRemoved || treeChanged;
       if (hasNewActivity) {


### PR DESCRIPTION
## Problem

A session is measured against the repo its `cwd` sits in. But a session is just as often started a level up — from a parent directory holding several repos side by side (`api/`, `web/`), or a plain `~/dev`.

That directory has no HEAD of its own, so `onSessionStart` records `startSha: ''`, `diffFor` returns `EMPTY_STATS` on every refresh, and the session is scored `idle` at the end regardless of what shipped inside it.

Repro, on `main`:

```
work/
  webapp/   (git repo)
  backend/  (git repo)
```

Start a Desktop session in `work/`, commit 40 lines in `webapp/` and 40 in `backend/`, end the session:

```
05 aug  work  2h11m  idle      ← before
05 aug  work  2h11m  shipped   ← after
```

Two commits, 80 lines, scored as nothing. This is the common shape for anyone whose product is more than one repo — the session where you change the API *and* the client is exactly the session that scores zero.

## Approach

A session now watches a **set** of repos instead of one:

| cwd | watched |
|---|---|
| inside a repo | that repo (unchanged) |
| a directory holding repos | the repos directly inside it |
| neither | nothing — session skipped |

Stats are summed across the set, so work spread over several repos in one session is counted once, in full.

Discovery (`discoverRepos` in `src/git.ts`) is a **filesystem** check — `existsSync(child/.git)`, which covers both a normal clone and the file form used by worktrees and submodules — so it costs no `git` spawn per candidate. It never recurses past one level and is bounded at 100 scanned entries and 10 repos, keeping it well inside the hook's budget.

## Notes / decisions

- **Baseline shape.** `startSha` becomes `repos: { path, startSha }[]`. `startSha` is still written (for single-repo sessions) and still read as a fallback, so sessions opened by an older CLI keep scoring correctly across the upgrade — verified with a hand-written legacy row.
- **Labelling.** One repo reads as that repo on its real branch, as today. Several read as the containing directory with `branch: 'multiple'` — no single branch describes the work. Deliberately not `'unknown'`, which `renderEndcard` uses to mean "no git" and would hide the stats.
- **Noise.** Desktop fires `SessionStart` for every session, including quick questions from a directory with no code under it. Those can never score, so they're now skipped instead of accumulating idle rows in `vibe log`. The shell wrapper still tracks a non-repo directory by wall clock — you invoke it deliberately, so the tradeoff differs.
- **`node_modules` and dotfiles** are excluded from the scan; a vendored `.git` inside a dependency would otherwise be tracked as a project.
- **Privacy unchanged.** Still `session_id` + `cwd` only, never the transcript. Discovery reads directory names, not file contents.
- **No new dependencies. No server changes** — the payload is unchanged; the server keeps recomputing momentum from raw stats.

## Testing

Verified end to end against a throwaway `$HOME` with real git repos:

- multi-repo parent: session opens, `project` = parent, `branch` = `multiple`, watches exactly 2 repos; commits in both are summed and score `shipped`
- single repo: `project` / `branch` / commit counting unchanged
- directory with no repos in or under it: no session row
- legacy row (`startSha`, no `repos`): still measured
- shell wrapper from a multi-repo parent: no longer prints `no git`
- `node_modules/pkg/.git` present: not tracked
- `tsc` clean
