### PR TITLE
fix: keep reading git while work is still landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This registers session hooks in `~/.claude/settings.json` — the same settings 
 
 Nothing else to run: Claude Code hot-reloads the settings, so just open a new Desktop session. Duration is measured the same way as the terminal — active coding time, with idle gaps over 30 minutes excluded.
 
+**Working across several repos?** Start the session wherever you like. If that directory isn't a repo itself, vibetime picks up the repos sitting directly inside it and measures all of them, so a session that touches `api/` and `web/` is scored on both. A directory with no repos in or under it isn't tracked — there'd be nothing to measure.
+
 If you use **both** the terminal wrapper and Desktop hooks, terminal `claude` sessions are counted once, not twice — the hooks stand down when the shell wrapper is already tracking.
 
 > **Why hooks use absolute paths** — the Desktop app, when launched from the Dock, doesn't inherit your shell `PATH`, so a bare `vibe` wouldn't resolve. `vibe hooks install` pins the absolute path to Node and the CLI so tracking works regardless of how Desktop is launched.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import { getSessions, reapOrphanedSessions } from './db.js';
+import { getSessions } from './db.js';
+import { refreshAndReap } from './rescore.js';
 import { readConfig, writeConfig, addTool } from './config.js';
 import { renderStatus, renderLog, renderLeaderboard } from './render.js';
 import { renderTerminalCard, writeHtmlCard } from './share.js';
@@ -65,7 +66,7 @@ program
   .command('status')
   .description("today's sessions")
   .action(async () => {
-    await reapOrphanedSessions();
+    await refreshAndReap();
     const sessions = getSessions();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -90,7 +91,7 @@ program
   .command('log')
   .description('full session history')
   .action(async () => {
-    await reapOrphanedSessions();
+    await refreshAndReap();
     const sessions = getSessions();
     const recent = sessions.slice(-20).reverse();
     console.log(renderLog(recent));
@@ -101,7 +102,7 @@ program
   .description("this week's share card")
   .option('--html', 'skip terminal card, open HTML directly')
   .action(async (opts: { html?: boolean }) => {
-    await reapOrphanedSessions();
+    await refreshAndReap();
     const sessions = getSessions();
 
     if (opts.html) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { readFileSync, writeFileSync, renameSync, mkdirSync, rmdirSync, unlinkSync, statSync, existsSync } from 'node:fs';
 import { VIBE_DIR, ensureVibeDir } from './config.js';
 import type { MomentumTier } from './score.js';
+import type { RepoBaseline } from './git.js';
 
 export interface Session {
   id: string;
@@ -22,7 +23,15 @@ export interface Session {
   // HEAD sha when the session started. Hook-tracked sessions (Claude Code Desktop)
   // record start and end in separate processes, so the baseline sha is persisted
   // here rather than held in memory like the shell-wrapped flow.
+  //
+  // Superseded by `repos`, which carries a baseline per repo. Still written, and
+  // still read as a fallback, so sessions recorded by an older CLI keep scoring
+  // correctly across an upgrade.
   startSha?: string;
+  // Every repo the session watches, each with its baseline HEAD: one entry for a
+  // session started inside a repo, several for one started from a directory that
+  // holds repos side by side.
+  repos?: RepoBaseline[];
 }
 
 interface DbSchema {

--- a/src/git.ts
+++ b/src/git.ts
@@ -52,10 +52,48 @@ export function getRepoRoot(cwd?: string): string {
   return run('git rev-parse --show-toplevel', cwd);
 }
 
-// A repo a session watches, paired with the HEAD it had when the session opened.
-export interface RepoBaseline {
+// A checkout of a repo, paired with the HEAD it had when the session opened.
+export interface CheckoutBaseline {
   path: string;
   startSha: string;
+}
+
+// A repo a session watches. Linked worktrees are checkouts of the same repo with
+// their own HEAD, so each carries its own baseline — without one, a worktree
+// parked on an old branch would read as work done during this session.
+export interface RepoBaseline extends CheckoutBaseline {
+  worktrees?: CheckoutBaseline[];
+}
+
+interface Worktree {
+  path: string;
+  head: string;
+}
+
+// Every checkout of a repo: the main one plus any linked worktree. Bare entries
+// have no HEAD and are skipped.
+export function listWorktrees(repoPath: string): Worktree[] {
+  const out = run('git worktree list --porcelain', repoPath);
+  if (!out) return [];
+
+  const trees: Worktree[] = [];
+  let path = '';
+  let head = '';
+  const flush = () => {
+    if (path && head) trees.push({ path, head });
+    path = '';
+    head = '';
+  };
+  for (const line of out.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      flush();
+      path = line.slice('worktree '.length);
+    } else if (line.startsWith('HEAD ')) {
+      head = line.slice('HEAD '.length);
+    }
+  }
+  flush();
+  return trees;
 }
 
 // The repos a session should measure. Usually that's the one repo the session
@@ -93,7 +131,12 @@ export function discoverRepos(cwd: string): string[] {
 }
 
 export function baselineRepos(cwd: string): RepoBaseline[] {
-  return discoverRepos(cwd).map((path) => ({ path, startSha: getHeadSha(path) }));
+  return discoverRepos(cwd).map((path) => {
+    const worktrees = listWorktrees(path)
+      .filter((t) => t.path !== path)
+      .map((t) => ({ path: t.path, startSha: t.head }));
+    return { path, startSha: getHeadSha(path), ...(worktrees.length ? { worktrees } : {}) };
+  });
 }
 
 // How a session labels itself. One repo reads as that repo on whatever branch it
@@ -133,7 +176,29 @@ export function getWorkingTreeFingerprint(cwd?: string): string {
 }
 
 export function getReposFingerprint(repos: RepoBaseline[]): string {
-  return repos.map((r) => `${r.path}\n${getWorkingTreeFingerprint(r.path)}`).join('\n');
+  return repos
+    .flatMap((r) => checkoutsOf(r).map((c) => `${c.path}\n${getWorkingTreeFingerprint(c.path)}`))
+    .join('\n');
+}
+
+function uncommittedStats(cwd: string) {
+  const hasHead = run('git rev-parse --verify HEAD', cwd) !== '';
+  return parseNumstat(
+    hasHead ? run('git diff --numstat HEAD', cwd) : run('git diff --numstat --cached', cwd)
+  );
+}
+
+// Every checkout of a repo as it stands right now, each with the baseline to
+// measure it from. A worktree created after the session opened has no baseline
+// of its own, so it is measured from the repo's — its commits are new by
+// definition.
+function checkoutsOf(repo: RepoBaseline): { path: string; head: string; startSha: string }[] {
+  const baselines = new Map<string, string>([[repo.path, repo.startSha]]);
+  for (const t of repo.worktrees ?? []) baselines.set(t.path, t.startSha);
+
+  const current = listWorktrees(repo.path);
+  const trees = current.length ? current : [{ path: repo.path, head: getHeadSha(repo.path) }];
+  return trees.map((t) => ({ ...t, startSha: baselines.get(t.path) ?? repo.startSha }));
 }
 
 export function getDiffStats(fromSha: string, toSha: string, cwd?: string): GitDiffStats {
@@ -163,13 +228,44 @@ export function getDiffStats(fromSha: string, toSha: string, cwd?: string): GitD
   return { commits, linesAdded, linesRemoved, filesTouched: allFiles.size };
 }
 
+// Committed work across every checkout of one repo, counted once. Asking for the
+// commits reachable from any current tip but from no baseline is what makes a
+// worktree count: its commits never move the main checkout's HEAD, but they are
+// reachable from the worktree's tip and from no baseline. Merging that worktree
+// back mid-session doesn't double count either — the commits land in the same
+// reachability set whether one tip or two can see them.
+function committedStats(checkouts: { path: string; head: string; startSha: string }[], repoPath: string): GitDiffStats {
+  const bases = [...new Set(checkouts.map((c) => c.startSha).filter(isSha))];
+  const tips = [...new Set(checkouts.map((c) => c.head).filter(isSha))].filter((t) => !bases.includes(t));
+  if (bases.length === 0 || tips.length === 0) {
+    return { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
+  }
+
+  const range = [...bases.map((b) => `^${b}`), ...tips].join(' ');
+  const commits = parseInt(run(`git rev-list --count ${range}`, repoPath), 10) || 0;
+  // Per-commit numstat rather than a net range diff: a range diff needs a single
+  // tip, and summing one per tip would count shared history twice. Merge commits
+  // report no numstat, so merged work is counted where it was written.
+  const { added, removed, files } = parseNumstat(run(`git log --format= --numstat ${range}`, repoPath));
+  return { commits, linesAdded: added, linesRemoved: removed, filesTouched: files.size };
+}
+
 // Stats for every repo the session watches, summed. Files are counted per repo
 // and added up — two repos can hold the same relative path without it being the
 // same file, so there is nothing to de-duplicate across them.
 export function getReposDiffStats(repos: RepoBaseline[]): GitDiffStats {
   const total: GitDiffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
   for (const repo of repos) {
-    const stats = getDiffStats(repo.startSha, getHeadSha(repo.path), repo.path);
+    const checkouts = checkoutsOf(repo);
+    const stats = committedStats(checkouts, repo.path);
+    // Uncommitted work lives in one working tree at a time, so no checkout can
+    // overlap another here.
+    for (const checkout of checkouts) {
+      const uncommitted = uncommittedStats(checkout.path);
+      stats.linesAdded += uncommitted.added;
+      stats.linesRemoved += uncommitted.removed;
+      stats.filesTouched += uncommitted.files.size;
+    }
     total.commits += stats.commits;
     total.linesAdded += stats.linesAdded;
     total.linesRemoved += stats.linesRemoved;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { existsSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import { basename, isAbsolute, join, resolve } from 'node:path';
 
 const SHA_RE = /^[0-9a-f]{4,40}$/;
 
@@ -119,15 +119,60 @@ export function discoverRepos(cwd: string): string[] {
     return [];
   }
 
-  const repos: string[] = [];
+  const candidates: string[] = [];
   for (const name of entries.slice(0, MAX_SCANNED_ENTRIES)) {
-    if (repos.length >= MAX_DISCOVERED_REPOS) break;
     const child = join(cwd, name);
     // `.git` is a directory in a normal clone and a file in a worktree or
     // submodule — existsSync covers both.
-    if (existsSync(join(child, '.git'))) repos.push(child);
+    if (existsSync(join(child, '.git'))) candidates.push(child);
   }
-  return repos;
+  return dedupeByRepo(candidates).slice(0, MAX_DISCOVERED_REPOS);
+}
+
+// A repo cloned next to a linked worktree of itself is exactly the layout the
+// worktree-counting below exists for, and both sides have a `.git` — so they
+// surface as two candidates here even though they're one underlying repo.
+// Keeping both would double count everything: once as the worktree's own
+// top-level entry, and again inside the repo's own worktree list. Keep one
+// entry per repo, preferring the main checkout — its worktree list enumerates
+// every linked checkout, a linked worktree's list of itself does not.
+function dedupeByRepo(candidates: string[]): string[] {
+  const chosen = new Map<string, string>(); // git-common-dir -> chosen path
+  const order: string[] = [];
+  for (const path of candidates) {
+    const key = getGitCommonDir(path) || path;
+    const existing = chosen.get(key);
+    if (!existing) {
+      chosen.set(key, path);
+      order.push(key);
+    } else if (!isMainCheckout(existing) && isMainCheckout(path)) {
+      chosen.set(key, path);
+    }
+  }
+  return order.map((key) => chosen.get(key)!);
+}
+
+function getGitCommonDir(cwd: string): string {
+  const out = run('git rev-parse --git-common-dir', cwd);
+  if (!out) return '';
+  const abs = isAbsolute(out) ? out : resolve(cwd, out);
+  // Git resolves symlinks when it writes a linked worktree's gitdir pointer, so
+  // its --git-common-dir comes back through e.g. /private/var on macOS while
+  // the main checkout's relative ".git" resolves through the un-resolved cwd —
+  // same directory, two different strings. realpath normalizes both sides.
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+function isMainCheckout(path: string): boolean {
+  try {
+    return statSync(join(path, '.git')).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 export function baselineRepos(cwd: string): RepoBaseline[] {
@@ -228,17 +273,24 @@ export function getDiffStats(fromSha: string, toSha: string, cwd?: string): GitD
   return { commits, linesAdded, linesRemoved, filesTouched: allFiles.size };
 }
 
+interface CommittedStats {
+  commits: number;
+  linesAdded: number;
+  linesRemoved: number;
+  files: Set<string>;
+}
+
 // Committed work across every checkout of one repo, counted once. Asking for the
 // commits reachable from any current tip but from no baseline is what makes a
 // worktree count: its commits never move the main checkout's HEAD, but they are
 // reachable from the worktree's tip and from no baseline. Merging that worktree
 // back mid-session doesn't double count either — the commits land in the same
 // reachability set whether one tip or two can see them.
-function committedStats(checkouts: { path: string; head: string; startSha: string }[], repoPath: string): GitDiffStats {
+function committedStats(checkouts: { path: string; head: string; startSha: string }[], repoPath: string): CommittedStats {
   const bases = [...new Set(checkouts.map((c) => c.startSha).filter(isSha))];
   const tips = [...new Set(checkouts.map((c) => c.head).filter(isSha))].filter((t) => !bases.includes(t));
   if (bases.length === 0 || tips.length === 0) {
-    return { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
+    return { commits: 0, linesAdded: 0, linesRemoved: 0, files: new Set() };
   }
 
   const range = [...bases.map((b) => `^${b}`), ...tips].join(' ');
@@ -247,7 +299,7 @@ function committedStats(checkouts: { path: string; head: string; startSha: strin
   // tip, and summing one per tip would count shared history twice. Merge commits
   // report no numstat, so merged work is counted where it was written.
   const { added, removed, files } = parseNumstat(run(`git log --format= --numstat ${range}`, repoPath));
-  return { commits, linesAdded: added, linesRemoved: removed, filesTouched: files.size };
+  return { commits, linesAdded: added, linesRemoved: removed, files };
 }
 
 // Stats for every repo the session watches, summed. Files are counted per repo
@@ -257,19 +309,24 @@ export function getReposDiffStats(repos: RepoBaseline[]): GitDiffStats {
   const total: GitDiffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
   for (const repo of repos) {
     const checkouts = checkoutsOf(repo);
-    const stats = committedStats(checkouts, repo.path);
-    // Uncommitted work lives in one working tree at a time, so no checkout can
-    // overlap another here.
+    const committed = committedStats(checkouts, repo.path);
+    let linesAdded = committed.linesAdded;
+    let linesRemoved = committed.linesRemoved;
+    // A file already touched by a commit this session can also be sitting
+    // uncommitted right now — union rather than sum so it isn't counted twice.
+    // Uncommitted work itself lives in one working tree at a time, so no
+    // checkout can overlap another there.
+    const files = new Set(committed.files);
     for (const checkout of checkouts) {
       const uncommitted = uncommittedStats(checkout.path);
-      stats.linesAdded += uncommitted.added;
-      stats.linesRemoved += uncommitted.removed;
-      stats.filesTouched += uncommitted.files.size;
+      linesAdded += uncommitted.added;
+      linesRemoved += uncommitted.removed;
+      for (const f of uncommitted.files) files.add(f);
     }
-    total.commits += stats.commits;
-    total.linesAdded += stats.linesAdded;
-    total.linesRemoved += stats.linesRemoved;
-    total.filesTouched += stats.filesTouched;
+    total.commits += committed.commits;
+    total.linesAdded += linesAdded;
+    total.linesRemoved += linesRemoved;
+    total.filesTouched += files.size;
   }
   return total;
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,9 +1,16 @@
 import { execSync } from 'node:child_process';
-import { basename } from 'node:path';
+import { existsSync, readdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
 
 const SHA_RE = /^[0-9a-f]{4,40}$/;
 
 const GIT_TIMEOUT_MS = 3_000;
+
+// Bounds for the one-level repo scan below. A container directory with more
+// entries than this is almost certainly not a project root, and tracking every
+// repo under it would cost a git spawn each on every refresh.
+const MAX_SCANNED_ENTRIES = 100;
+const MAX_DISCOVERED_REPOS = 10;
 
 function run(cmd: string, cwd?: string) {
   try {
@@ -41,6 +48,64 @@ export function getProjectName(cwd?: string): string {
   return basename(cwd || process.cwd());
 }
 
+export function getRepoRoot(cwd?: string): string {
+  return run('git rev-parse --show-toplevel', cwd);
+}
+
+// A repo a session watches, paired with the HEAD it had when the session opened.
+export interface RepoBaseline {
+  path: string;
+  startSha: string;
+}
+
+// The repos a session should measure. Usually that's the one repo the session
+// started inside. But a session is just as often started from a directory that
+// holds several repos side by side — a monorepo-ish parent like ~/work/acme with
+// `api/` and `web/` in it, or a plain ~/dev. That directory has no HEAD of its
+// own, so measuring only `cwd` scores every such session as idle no matter how
+// much shipped. So: fall back to the repos one level down.
+//
+// Discovery is a filesystem check rather than a git spawn per child, and never
+// recurses past one level, so it stays cheap enough to run inside a hook.
+export function discoverRepos(cwd: string): string[] {
+  const root = getRepoRoot(cwd);
+  if (root) return [root];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(cwd, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith('.') && e.name !== 'node_modules')
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+
+  const repos: string[] = [];
+  for (const name of entries.slice(0, MAX_SCANNED_ENTRIES)) {
+    if (repos.length >= MAX_DISCOVERED_REPOS) break;
+    const child = join(cwd, name);
+    // `.git` is a directory in a normal clone and a file in a worktree or
+    // submodule — existsSync covers both.
+    if (existsSync(join(child, '.git'))) repos.push(child);
+  }
+  return repos;
+}
+
+export function baselineRepos(cwd: string): RepoBaseline[] {
+  return discoverRepos(cwd).map((path) => ({ path, startSha: getHeadSha(path) }));
+}
+
+// How a session labels itself. One repo reads as that repo on whatever branch it
+// is on; several read as the directory holding them, since no single branch
+// describes the work.
+export function describeRepos(repos: RepoBaseline[], cwd: string): { project: string; branch: string } {
+  if (repos.length === 1) {
+    return { project: getProjectName(repos[0].path), branch: getBranch(repos[0].path) };
+  }
+  return { project: basename(cwd) || 'unknown', branch: 'multiple' };
+}
+
 export interface GitDiffStats {
   commits: number;
   linesAdded: number;
@@ -65,6 +130,10 @@ function parseNumstat(numstat: string) {
 
 export function getWorkingTreeFingerprint(cwd?: string): string {
   return run('git status --porcelain', cwd);
+}
+
+export function getReposFingerprint(repos: RepoBaseline[]): string {
+  return repos.map((r) => `${r.path}\n${getWorkingTreeFingerprint(r.path)}`).join('\n');
 }
 
 export function getDiffStats(fromSha: string, toSha: string, cwd?: string): GitDiffStats {
@@ -92,4 +161,19 @@ export function getDiffStats(fromSha: string, toSha: string, cwd?: string): GitD
   for (const f of uncommitted.files) allFiles.add(f);
 
   return { commits, linesAdded, linesRemoved, filesTouched: allFiles.size };
+}
+
+// Stats for every repo the session watches, summed. Files are counted per repo
+// and added up — two repos can hold the same relative path without it being the
+// same file, so there is nothing to de-duplicate across them.
+export function getReposDiffStats(repos: RepoBaseline[]): GitDiffStats {
+  const total: GitDiffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
+  for (const repo of repos) {
+    const stats = getDiffStats(repo.startSha, getHeadSha(repo.path), repo.path);
+    total.commits += stats.commits;
+    total.linesAdded += stats.linesAdded;
+    total.linesRemoved += stats.linesRemoved;
+    total.filesTouched += stats.filesTouched;
+  }
+  return total;
 }

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,5 +1,6 @@
-import { addSession, updateSession, getSessions, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
+import { addSession, updateSession, getSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
 import { isGitRepo, getHeadSha, getDiffStats, getReposDiffStats, baselineRepos, describeRepos, type GitDiffStats } from './git.js';
+import { refreshAndReap } from './rescore.js';
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { flushPendingSubmissions } from './submit.js';
@@ -82,7 +83,7 @@ export async function handleHook(event: string, raw: string): Promise<void> {
 }
 
 async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
-  await reapOrphanedSessions();
+  await refreshAndReap();
 
   // SessionStart also fires on resume/clear/compact — key off the Claude
   // session id so a session is only opened once.

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,5 +1,5 @@
 import { addSession, updateSession, getSessions, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
-import { isGitRepo, getHeadSha, getBranch, getProjectName, getDiffStats, type GitDiffStats } from './git.js';
+import { isGitRepo, getHeadSha, getDiffStats, getReposDiffStats, baselineRepos, describeRepos, type GitDiffStats } from './git.js';
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { flushPendingSubmissions } from './submit.js';
@@ -34,6 +34,9 @@ function activeSecondsSince(lastActivityAt: string | undefined, startedAt: strin
 }
 
 function diffFor(session: Session, cwd: string): GitDiffStats {
+  if (session.repos?.length) return getReposDiffStats(session.repos);
+  // Fallback for sessions opened by an older CLI, which recorded a single
+  // baseline sha against the session cwd.
   if (!session.startSha || !isGitRepo(cwd)) return EMPTY_STATS;
   return getDiffStats(session.startSha, getHeadSha(cwd), cwd);
 }
@@ -85,15 +88,21 @@ async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
   // session id so a session is only opened once.
   if (getSessions().some((s) => s.id === sessionId)) return;
 
-  const hasGit = isGitRepo(cwd);
+  // The repo the session started in, or — when it started from a directory that
+  // holds repos rather than being one — the repos inside it. Desktop fires
+  // SessionStart for every session, including quick questions asked from a
+  // directory with no code under it at all; those can never score, so skip them
+  // instead of piling up idle rows in `vibe log`.
+  const repos = baselineRepos(cwd);
+  if (repos.length === 0) return;
+
   const startedAt = new Date().toISOString();
   const config = readConfig();
 
   const session: Session = {
     id: sessionId,
     tool: 'claude',
-    project: hasGit ? getProjectName(cwd) : cwd.split('/').pop() || 'unknown',
-    branch: hasGit ? getBranch(cwd) : 'unknown',
+    ...describeRepos(repos, cwd),
     startedAt,
     endedAt: startedAt,
     durationSeconds: 0,
@@ -101,7 +110,8 @@ async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
     momentum: scoreSession({ ...EMPTY_STATS, exitCode: -1 }, config),
     exitCode: -1,
     lastActivityAt: startedAt,
-    startSha: hasGit ? getHeadSha(cwd) : '',
+    startSha: repos.length === 1 ? repos[0].startSha : '',
+    repos,
   };
 
   try {

--- a/src/rescore.ts
+++ b/src/rescore.ts
@@ -1,0 +1,76 @@
+import { getSessions, updateSession, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
+import { getReposDiffStats } from './git.js';
+import { readConfig } from './config.js';
+import { scoreSession } from './score.js';
+
+// How long after a session ends its work can still land. You close the tab and
+// commit from the terminal a minute later; you step away mid-task and come back
+// to finish. The window matches the inactivity timeout used everywhere else.
+const GRACE_MS = INACTIVITY_TIMEOUT_MS;
+
+function statsChanged(session: Session, stats: { commits: number; linesAdded: number; linesRemoved: number; filesTouched: number }): boolean {
+  return (
+    session.commits !== stats.commits ||
+    session.linesAdded !== stats.linesAdded ||
+    session.linesRemoved !== stats.linesRemoved ||
+    session.filesTouched !== stats.filesTouched
+  );
+}
+
+// A later session watching the same repo has its own baseline, taken after this
+// one closed, so anything committed from then on belongs to it. Without this
+// check the same commit could be credited to both.
+function supersededBy(session: Session, all: Session[]): boolean {
+  const endedMs = Date.parse(session.endedAt);
+  const paths = new Set((session.repos ?? []).map((r) => r.path));
+  return all.some(
+    (other) =>
+      other.id !== session.id &&
+      Date.parse(other.startedAt) >= endedMs &&
+      (other.repos ?? []).some((r) => paths.has(r.path)),
+  );
+}
+
+// Re-read git for sessions whose stats can still move: the ones still open, and
+// the ones that closed recently enough that work is still landing in them.
+//
+// This is what keeps an abandoned session honest. The reaper closes anything
+// idle for 30 minutes, but it only writes a duration — the stats stay frozen at
+// the last hook event. Commit, then shut the laptop without ending the session,
+// and the commit is never read: the session is submitted with zero. Refreshing
+// before the reaper runs means the work is recorded whether or not you came back
+// to end it cleanly.
+export async function refreshRecentSessions(): Promise<void> {
+  const now = Date.now();
+  const all = getSessions();
+  const config = readConfig();
+
+  for (const session of all) {
+    // Sessions from an older CLI have no repo baselines to measure against.
+    if (!session.repos?.length) continue;
+
+    const open = session.exitCode === -1;
+    if (!open) {
+      if (now - Date.parse(session.endedAt) > GRACE_MS) continue;
+      if (supersededBy(session, all)) continue;
+    }
+
+    const stats = getReposDiffStats(session.repos);
+    if (!statsChanged(session, stats)) continue;
+
+    await updateSession(session.id, {
+      ...stats,
+      momentum: scoreSession({ ...stats, exitCode: session.exitCode }, config),
+      // The corrected state has to reach the server; it upserts on id, so
+      // resubmitting is safe.
+      submittedAt: undefined,
+    });
+  }
+}
+
+// Refresh first, then reap: a session the reaper is about to close carries the
+// work it actually did rather than whatever the last hook event happened to see.
+export async function refreshAndReap(): Promise<void> {
+  await refreshRecentSessions();
+  await reapOrphanedSessions();
+}

--- a/src/rescore.ts
+++ b/src/rescore.ts
@@ -17,18 +17,24 @@ function statsChanged(session: Session, stats: { commits: number; linesAdded: nu
   );
 }
 
-// A later session watching the same repo has its own baseline, taken after this
-// one closed, so anything committed from then on belongs to it. Without this
-// check the same commit could be credited to both.
-function supersededBy(session: Session, all: Session[]): boolean {
+// Whether another session already owns anything that lands in this repo from
+// here on, so refreshing this one would double-credit it. Two cases:
+//
+//  - a session watching the same repo is open right now. It will pick up
+//    whatever lands next on its own; it doesn't matter whether it started
+//    before or after this one closed — sessions on a shared repo can overlap
+//    for their whole open lifetime, not just across the grace window.
+//  - a session watching the same repo started after this one closed. Its
+//    baseline was taken later, so anything committed from then on is its to
+//    claim even once it, too, eventually closes.
+function ownedByAnotherSession(session: Session, all: Session[]): boolean {
   const endedMs = Date.parse(session.endedAt);
   const paths = new Set((session.repos ?? []).map((r) => r.path));
-  return all.some(
-    (other) =>
-      other.id !== session.id &&
-      Date.parse(other.startedAt) >= endedMs &&
-      (other.repos ?? []).some((r) => paths.has(r.path)),
-  );
+  return all.some((other) => {
+    if (other.id === session.id) return false;
+    if (!(other.repos ?? []).some((r) => paths.has(r.path))) return false;
+    return other.exitCode === -1 || Date.parse(other.startedAt) >= endedMs;
+  });
 }
 
 // Re-read git for sessions whose stats can still move: the ones still open, and
@@ -52,7 +58,7 @@ export async function refreshRecentSessions(): Promise<void> {
     const open = session.exitCode === -1;
     if (!open) {
       if (now - Date.parse(session.endedAt) > GRACE_MS) continue;
-      if (supersededBy(session, all)) continue;
+      if (ownedByAnotherSession(session, all)) continue;
     }
 
     const stats = getReposDiffStats(session.repos);

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { addSession, updateSession, deleteSession, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
-import { isGitRepo, getHeadSha, getBranch, getProjectName, getDiffStats, getWorkingTreeFingerprint } from './git.js';
+import { baselineRepos, describeRepos, getReposDiffStats, getReposFingerprint } from './git.js';
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { renderEndcard } from './render.js';
@@ -33,10 +33,14 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
 
   const cwd = process.cwd();
   const startedAt = new Date().toISOString();
-  const hasGit = isGitRepo(cwd);
-  const startSha = hasGit ? getHeadSha(cwd) : '';
-  const branch = hasGit ? getBranch(cwd) : 'unknown';
-  const project = hasGit ? getProjectName(cwd) : cwd.split('/').pop() || 'unknown';
+  // The repo this was launched in, or the repos inside the directory it was
+  // launched from. Unlike the Desktop hooks, the wrapper still tracks a
+  // directory with no repos at all by wall clock — you invoked it deliberately.
+  const repos = baselineRepos(cwd);
+  const hasGit = repos.length > 0;
+  const { project, branch } = hasGit
+    ? describeRepos(repos, cwd)
+    : { project: cwd.split('/').pop() || 'unknown', branch: 'unknown' };
   const config = readConfig();
   const sessionId = randomUUID();
   let lastActivityAt = startedAt;
@@ -54,8 +58,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
 
     let diffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
     if (hasGit) {
-      const endSha = getHeadSha(cwd);
-      diffStats = getDiffStats(startSha, endSha, cwd);
+      diffStats = getReposDiffStats(repos);
     }
     const momentum = scoreSession({ ...diffStats, exitCode }, config);
     return { endedAt, durationSeconds, ...diffStats, momentum, exitCode, lastActivityAt };
@@ -66,6 +69,8 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
   const session: Session = {
     id: sessionId, tool, project, branch, startedAt,
     ...initial,
+    startSha: repos.length === 1 ? repos[0].startSha : '',
+    repos,
   };
   try { await addSession(session); } catch (e) {
     console.error(`  vibe: failed to save session — ${e instanceof Error ? e.message : 'unknown error'}`);
@@ -75,7 +80,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
   let prevCommits = initial.commits;
   let prevLinesAdded = initial.linesAdded;
   let prevLinesRemoved = initial.linesRemoved;
-  let prevTreeState = hasGit ? getWorkingTreeFingerprint(cwd) : '';
+  let prevTreeState = hasGit ? getReposFingerprint(repos) : '';
   let lastInProgressSubmitAt = 0;
   const poll = setInterval(async () => {
     try {
@@ -88,7 +93,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
       }
 
       const snap = snapshot(-1);
-      const treeState = hasGit ? getWorkingTreeFingerprint(cwd) : '';
+      const treeState = hasGit ? getReposFingerprint(repos) : '';
       const treeChanged = treeState !== prevTreeState;
       const hasNewActivity = snap.commits > prevCommits || snap.linesAdded > prevLinesAdded || snap.linesRemoved > prevLinesRemoved || treeChanged;
       if (hasNewActivity) {

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -1,7 +1,8 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { addSession, updateSession, deleteSession, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
+import { addSession, updateSession, deleteSession, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
 import { baselineRepos, describeRepos, getReposDiffStats, getReposFingerprint } from './git.js';
+import { refreshAndReap } from './rescore.js';
 import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { renderEndcard } from './render.js';
@@ -47,7 +48,7 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
   let totalGapMs = 0;
   let idleSince = 0;
 
-  await reapOrphanedSessions();
+  await refreshAndReap();
 
   function snapshot(exitCode: number): Pick<Session, 'endedAt' | 'durationSeconds' | 'commits' | 'linesAdded' | 'linesRemoved' | 'filesTouched' | 'momentum' | 'exitCode' | 'lastActivityAt'> {
     const endedAt = new Date().toISOString();


### PR DESCRIPTION
> Stacked on #16 and #17 — the diff to review here is the last commit.

## Problem

Two ways a session loses work it genuinely did.

**1. You step away instead of closing down.** The reaper finalizes anything idle for 30 minutes, but it only writes a duration — stats stay frozen at whatever the last hook event happened to see. Commit, then shut the laptop without ending the session, and that commit is never read. The session is submitted with zero.

```
# commit 80 lines, walk away, never return to the session
05 aug  app  38m  idle         ← before  (the commit is right there in git)
05 aug  app  38m  interrupted  ← after, locally — the reaper's exitCode still
                                  reads as interrupted; the leaderboard, which
                                  scores from raw stats and ignores exitCode,
                                  sees it as shipped
```

**2. You commit a minute after closing the tab.** The work was already there — it was in the diff when the session ended — but as uncommitted lines, so `commits: 0` and the session scores `tinkering` instead of `shipped`.

## Approach

Sessions are re-read from git while their stats can still move: while open, and for 30 minutes after they close (`GRACE_MS`, the same inactivity constant used everywhere else).

The refresh runs **before** the reaper, so a session the reaper is about to close carries the work it actually did rather than whatever the last event saw. Corrected stats clear `submittedAt` and resubmit on the next flush — the server upserts on id, the same route #14's reaper-recovery fix relies on.

Wired into the existing `reapOrphanedSessions()` call sites via `refreshAndReap()`, so `vibe status`, `vibe log`, `vibe share`, a new session opening, and the wrapper all pick it up. No new commands, no new timers.

## Notes / decisions

- **A commit is credited to exactly one session.** If another session watching the same repo is open right now, or started after this one closed, that session owns anything landing from here on and this one leaves it alone (`ownedByAnotherSession`) — covers both a strictly later session and two sessions genuinely overlapping in time.
- **The window is deliberately short.** Past 30 minutes a closed session is final. Work that lands hours later belongs to whichever session was open at the time — crediting it backwards would be inventing history, and the daily `shipped` cap makes that worth being careful about.
- **`interrupted` is left alone.** A reaped session keeps `exitCode: 1` and reads as `interrupted` locally; only its stats are corrected. The server scores from raw stats and ignores the tier, so the leaderboard sees the work either way, and `wasReapedInterrupted` keeps working unchanged.
- **Sessions from an older CLI** have no repo baselines and are skipped — nothing to measure against.
- Storage stays git-free: the new pass lives in `src/rescore.ts`, `db.ts` keeps its single responsibility.
- No new dependencies, no server changes, privacy model unchanged.

## Testing

Against a throwaway `$HOME` with real repos:

- commit one minute after `SessionEnd`: credited, rescored `shipped`, `submittedAt` cleared for resubmission
- commit 45 minutes after: **not** credited, session left final
- a strictly later session on the same repo: it claims the commit, the earlier one doesn't
- genuine overlap — session A opens, session B opens, B closes while A is still open, then a commit lands: A claims it, B (in its own grace window) doesn't
- laptop-shut simulation (open session, commit, idle past the timeout): reaper closes it **with** the commit intact
- legacy row with `startSha` and no `repos`: untouched
- #16 and #17 suites re-run green
- `tsc` clean

---

**Update:** addressed both review comments — a closed session no longer double-credits a commit that a still-open session on the same repo will also count (`ownedByAnotherSession` now checks for that, not just later start times), and the description above no longer claims the walk-away example reads `shipped` locally; it reads `interrupted` locally and `shipped` only on the leaderboard, which was the actual, correct behavior all along. Rebased onto #17's fix.
