### PR TITLE
test: score parity sweep and git counting regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "test": "tsc && node --test test/*.test.mjs",
     "prepublishOnly": "tsc",
     "postinstall": "echo \"\\n  ◆ vibetime installed. run 'vibe init' to complete setup.\\n\""
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export interface VibeConfig {
 export const VIBE_DIR = join(homedir(), '.vibe');
 const CONFIG_PATH = join(VIBE_DIR, 'config.json');
 
-const DEFAULTS: VibeConfig = {
+export const DEFAULTS: VibeConfig = {
   thresholdLines: 50,
   thresholdFiles: 3,
 };

--- a/test/git-stats.test.mjs
+++ b/test/git-stats.test.mjs
@@ -1,0 +1,122 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import { execSync } from 'node:child_process';
+import { baselineRepos, discoverRepos, getReposDiffStats } from '../dist/git.js';
+
+function sh(cmd, cwd) {
+  execSync(cmd, { cwd, stdio: 'pipe' });
+}
+
+function initRepo(parent, name) {
+  sh(`git init -qb main ${name}`, parent);
+  const path = join(parent, name);
+  commit(path, 'init', { allowEmpty: true });
+  return path;
+}
+
+function commit(cwd, msg, { allowEmpty = false } = {}) {
+  sh(`git -c user.email=vibe@test -c user.name=vibe commit -q ${allowEmpty ? '--allow-empty ' : ''}-m ${msg}`, cwd);
+}
+
+function scratch(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'vibe-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+test('a file both committed and re-edited counts once', (t) => {
+  const dir = scratch(t);
+  const repo = initRepo(dir, 'repo');
+  const baseline = baselineRepos(repo);
+
+  writeFileSync(join(repo, 'f.txt'), 'one\n');
+  sh('git add f.txt', repo);
+  commit(repo, 'add');
+  writeFileSync(join(repo, 'f.txt'), 'two\n');
+
+  assert.deepEqual(getReposDiffStats(baseline), {
+    commits: 1,
+    linesAdded: 2,
+    linesRemoved: 1,
+    filesTouched: 1,
+  });
+});
+
+test('a repo and its sibling worktree are one repo, not two', (t) => {
+  const dir = scratch(t);
+  const repoA = initRepo(dir, 'repoA');
+  sh('git worktree add -q ../repoA-wt -b feat', repoA);
+  const repoB = initRepo(dir, 'repoB');
+  writeFileSync(join(repoB, 'b.txt'), 'base\n');
+  sh('git add b.txt', repoB);
+  commit(repoB, 'init-b');
+
+  const baseline = baselineRepos(dir);
+  assert.equal(baseline.length, 2);
+
+  writeFileSync(join(dir, 'repoA-wt', 'f.txt'), 'one\ntwo\n');
+  sh('git add f.txt', join(dir, 'repoA-wt'));
+  commit(join(dir, 'repoA-wt'), 'feat');
+  writeFileSync(join(repoB, 'b.txt'), 'changed\n');
+  sh('git add b.txt', repoB);
+  commit(repoB, 'edit');
+  writeFileSync(join(repoB, 'b.txt'), 'again\n');
+
+  assert.deepEqual(getReposDiffStats(baseline), {
+    commits: 2,
+    linesAdded: 4,
+    linesRemoved: 2,
+    filesTouched: 2,
+  });
+});
+
+test('the main checkout is kept no matter how the scan orders them', (t) => {
+  const dir = scratch(t);
+  const repo = initRepo(dir, 'zrepo');
+  // The worktree sorts before the main checkout, so dedupe must swap, not
+  // just keep the first candidate it sees.
+  sh('git worktree add -q ../aaa-wt -b feat', repo);
+
+  const discovered = discoverRepos(dir);
+  assert.equal(discovered.length, 1);
+  assert.equal(basename(discovered[0]), 'zrepo');
+});
+
+test('a commit made in a linked worktree counts from the main checkout', (t) => {
+  const dir = scratch(t);
+  const repo = initRepo(dir, 'repo');
+  sh(`git worktree add -q ${join(dir, 'wt')} -b feat`, repo);
+  const baseline = baselineRepos(repo);
+
+  writeFileSync(join(dir, 'wt', 'f.txt'), 'one\n');
+  sh('git add f.txt', join(dir, 'wt'));
+  commit(join(dir, 'wt'), 'feat');
+
+  assert.deepEqual(getReposDiffStats(baseline), {
+    commits: 1,
+    linesAdded: 1,
+    linesRemoved: 0,
+    filesTouched: 1,
+  });
+});
+
+test('a worktree parked on an old branch adds nothing', (t) => {
+  const dir = scratch(t);
+  const repo = initRepo(dir, 'repo');
+  writeFileSync(join(repo, 'f.txt'), 'one\n');
+  sh('git add f.txt', repo);
+  commit(repo, 'second');
+  sh('git branch old HEAD~1', repo);
+  sh(`git worktree add -q ${join(dir, 'wt')} old`, repo);
+
+  const baseline = baselineRepos(repo);
+  assert.deepEqual(getReposDiffStats(baseline), {
+    commits: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    filesTouched: 0,
+  });
+});

--- a/test/score-parity.test.mjs
+++ b/test/score-parity.test.mjs
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+import { scoreSession } from '../dist/score.js';
+import { DEFAULTS } from '../dist/config.js';
+
+// The server package never emits JS — wrangler bundles straight from TS — so
+// transpile its score module on the fly and import it as a data URI. The module
+// is dependency-free, which is what makes this possible.
+const serverSource = readFileSync(new URL('../server/src/score.ts', import.meta.url), 'utf-8');
+const { outputText } = ts.transpileModule(serverSource, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+});
+const server = await import('data:text/javascript;base64,' + Buffer.from(outputText).toString('base64'));
+
+// Values straddling both thresholds (lines > 50, files > 3), so a > drifting to
+// >= — or a constant drifting on either side — fails a case at the boundary.
+const COMMITS = [0, 1, 3];
+const LINES_ADDED = [0, 1, 24, 49, 50, 51, 200];
+const LINES_REMOVED = [0, 1, 26];
+const FILES_TOUCHED = [0, 1, 3, 4, 10];
+
+test('CLI and server score identically for every non-interrupted input', () => {
+  for (const commits of COMMITS) {
+    for (const linesAdded of LINES_ADDED) {
+      for (const linesRemoved of LINES_REMOVED) {
+        for (const filesTouched of FILES_TOUCHED) {
+          const stats = { commits, linesAdded, linesRemoved, filesTouched };
+          const cli = scoreSession({ ...stats, exitCode: 0 }, DEFAULTS);
+          const remote = server.scoreSession(stats);
+          assert.equal(cli, remote, `diverged on ${JSON.stringify(stats)}: cli=${cli} server=${remote}`);
+        }
+      }
+    }
+  }
+});
+
+test('interrupted is the one deliberate divergence: CLI-only, from exitCode', () => {
+  const stats = { commits: 5, linesAdded: 500, linesRemoved: 100, filesTouched: 20 };
+  assert.equal(scoreSession({ ...stats, exitCode: 1 }, DEFAULTS), 'interrupted');
+  // The server never sees an exitCode and must not have the tier at all — the
+  // leaderboard scores reaped sessions from their raw stats.
+  assert.equal(server.scoreSession(stats), 'shipped');
+  assert.ok(!serverSource.includes('interrupted'), 'server score.ts must not know about interrupted');
+});


### PR DESCRIPTION
Foundation item from the v0.5 list: the CLI and server each have a scoreSession, and they must agree for every non-interrupted input. This was verified by hand until now, and one silent edit on either side could split the endcard from the leaderboard.

## What's here

- `test/score-parity.test.mjs` runs a value grid straddling both thresholds (lines > 50, files > 3) through both implementations and asserts identical tiers. The server module is transpiled on the fly with the existing typescript devDependency, since wrangler never emits JS. A second test pins the one deliberate divergence: `interrupted` is CLI-only and comes from exitCode; the server must not know the tier exists.
- `test/git-stats.test.mjs` pins the counting behavior fixed in #17 with real temp repos: a sibling worktree is one repo, a file committed and then re-edited counts once, a worktree commit counts from the main checkout, and a worktree parked on an old branch adds nothing.
- `npm test` builds and runs everything through node:test. No new dependencies.
- `config.ts` now exports `DEFAULTS` so the parity test scores with the CLI's real default thresholds instead of a copy that could drift.

## Verified

- 7/7 pass on main.
- Sanity check that the sweep has teeth: simulating a server-side threshold change of 50 to 60 fails 27 cases.
