### PR TITLE
Fix tracking lost after a spurious Desktop SessionEnd

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { homedir, userInfo } from 'node:os';
 import { mkdirSync, chmodSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { createInterface } from 'node:readline';
@@ -14,7 +14,10 @@ export interface VibeConfig {
   thresholdFiles: number;
 }
 
-export const VIBE_DIR = join(homedir(), '.vibe');
+// Overridable so tests can run the full session flow against a scratch dir
+// instead of the real ~/.vibe. Resolved to absolute so a relative value can't
+// scatter one database per working directory.
+export const VIBE_DIR = process.env.VIBE_DIR ? resolve(process.env.VIBE_DIR) : join(homedir(), '.vibe');
 const CONFIG_PATH = join(VIBE_DIR, 'config.json');
 
 export const DEFAULTS: VibeConfig = {
@@ -23,9 +26,10 @@ export const DEFAULTS: VibeConfig = {
 };
 
 export function ensureVibeDir(): void {
-  const created = !existsSync(VIBE_DIR);
   mkdirSync(VIBE_DIR, { recursive: true });
-  if (created) chmodSync(VIBE_DIR, 0o700);
+  // Always, not just on create: sessions and auth are private, and an
+  // overridden VIBE_DIR may point at a dir that already exists more open.
+  chmodSync(VIBE_DIR, 0o700);
 }
 
 export function readConfig(): VibeConfig {

--- a/src/db.ts
+++ b/src/db.ts
@@ -32,6 +32,11 @@ export interface Session {
   // session started inside a repo, several for one started from a directory that
   // holds repos side by side.
   repos?: RepoBaseline[];
+  // Set when the session has ended cleanly at least once. A hook session can be
+  // reopened by later events carrying the same Claude session id (see hook.ts);
+  // if it then goes idle, the reaper re-finalizes it as the clean end it already
+  // had instead of downgrading it to `interrupted`.
+  hadCleanEnd?: boolean;
 }
 
 interface DbSchema {
@@ -166,12 +171,22 @@ export async function reapOrphanedSessions(): Promise<void> {
       const lastMs = new Date(s.lastActivityAt || s.startedAt).getTime();
       if (now - lastMs <= INACTIVITY_TIMEOUT_MS) continue;
 
-      const startMs = new Date(s.startedAt).getTime();
-      const cappedEndMs = lastMs + INACTIVITY_TIMEOUT_MS;
-      s.durationSeconds = Math.round(Math.max(cappedEndMs - startMs, 0) / 1000);
-      s.endedAt = new Date(cappedEndMs).toISOString();
-      s.exitCode = 1;
-      s.momentum = 'interrupted';
+      // durationSeconds is accumulated live with idle gaps excluded (hook
+      // events and the wrapper poller both do this), so extend it by the same
+      // capped tail the live path grants — never recompute from wall clock,
+      // which would re-include every excluded gap. endedAt lands at the cutoff
+      // so the rescore grace window still covers work committed just after.
+      s.durationSeconds += Math.round(INACTIVITY_TIMEOUT_MS / 1000);
+      s.endedAt = new Date(lastMs + INACTIVITY_TIMEOUT_MS).toISOString();
+      if (s.hadCleanEnd) {
+        // Revived after a clean end (see hook.ts): idling out again is not an
+        // interruption — re-finalize as the clean end it already had, keeping
+        // the momentum scored against live stats.
+        s.exitCode = 0;
+      } else {
+        s.exitCode = 1;
+        s.momentum = 'interrupted';
+      }
       changed = true;
     }
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { addSession, updateSession, getSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
 import { isGitRepo, getHeadSha, getDiffStats, getReposDiffStats, baselineRepos, describeRepos, type GitDiffStats } from './git.js';
 import { refreshAndReap } from './rescore.js';
@@ -34,25 +35,49 @@ function activeSecondsSince(lastActivityAt: string | undefined, startedAt: strin
   return Math.round(Math.min(gap, INACTIVITY_TIMEOUT_MS) / 1000);
 }
 
-function diffFor(session: Session, cwd: string): GitDiffStats {
-  if (session.repos?.length) return getReposDiffStats(session.repos);
+// What the session's repos show now, or null when they can't be measured — a
+// moved or deleted repo reads as an all-zero diff (git failures return empty
+// output), and a zero must never overwrite real recorded stats on a revival.
+function diffFor(session: Session, cwd: string): GitDiffStats | null {
+  if (session.repos?.length) {
+    const alive = session.repos.filter((r) => existsSync(r.path));
+    return alive.length ? getReposDiffStats(alive) : null;
+  }
   // Fallback for sessions opened by an older CLI, which recorded a single
   // baseline sha against the session cwd.
-  if (!session.startSha || !isGitRepo(cwd)) return EMPTY_STATS;
+  if (!session.startSha || !isGitRepo(cwd)) return null;
   return getDiffStats(session.startSha, getHeadSha(cwd), cwd);
 }
 
-// The shared reaper (reapOrphanedSessions) finalizes any idle in-progress
-// session as `interrupted` after 30 minutes — it runs on every vibe status/log/
-// share and inside onSessionStart. Terminal sessions survive it because their
-// poller rewrites the row every 30s; a hook session only writes on hook events,
-// so a Desktop session idle over a lunch break gets reaped mid-flight. When the
-// user comes back and ships, we must reopen it — otherwise the later activity
-// and session-end events bail on the `exitCode !== -1` guard and the session is
-// frozen as interrupted with the work lost. A normally-ended hook session has
-// exitCode 0 and never scores `interrupted`, so this only matches the reaper.
-function wasReapedInterrupted(session: Session): boolean {
-  return session.exitCode !== -1 && session.momentum === 'interrupted';
+// A finalized hook session must come back to life when later events arrive for
+// its id, or the remaining work is silently dropped. Two kinds of revival:
+//
+//  - 'reaped': the shared reaper (reapOrphanedSessions) finalized it as
+//    `interrupted` after 30 idle minutes. Terminal sessions survive the reaper
+//    because their poller rewrites the row every 30s; a hook session only
+//    writes on hook events, so a Desktop session idle over a lunch break gets
+//    reaped mid-flight. Any later event revives it, however long the break —
+//    the reap itself is proof the session never really ended — and the idle
+//    gap stays uncounted because the reap already granted the active tail.
+//
+//  - 'clean': Desktop sometimes fires a spurious clean SessionEnd seconds
+//    after SessionStart while the conversation runs on for hours (issue #19).
+//    Only events inside the inactivity window of that end revive it, and the
+//    gap counts as active time — as if the end never happened. Past the
+//    window a clean end is final: reviving a days-old session (`--resume`)
+//    would re-diff from its stale baseline and double-credit work that later
+//    sessions on the same repos already claimed.
+//
+// Sessions that ended cleanly once carry `hadCleanEnd`, so a revived one that
+// idles out again re-finalizes clean instead of downgrading to `interrupted`
+// (the reaper checks it — see db.ts). SessionStart alone never revives:
+// resuming a conversation just to look at it isn't work, and the first prompt
+// or tool call revives it within the same second anyway.
+function reopenKind(session: Session, now: number): 'reaped' | 'clean' | null {
+  if (session.exitCode === -1) return null; // still open — nothing to revive
+  if (session.momentum === 'interrupted') return 'reaped';
+  if (now - new Date(session.endedAt).getTime() <= INACTIVITY_TIMEOUT_MS) return 'clean';
+  return null;
 }
 
 export async function handleHook(event: string, raw: string): Promise<void> {
@@ -124,33 +149,35 @@ async function onActivity(sessionId: string, cwd: string): Promise<void> {
   const session = getSessions().find((s) => s.id === sessionId);
   if (!session) return;
 
-  const reopening = wasReapedInterrupted(session);
-  if (session.exitCode !== -1 && !reopening) return; // finalized normally — ignore late events
-
   const now = Date.now();
+  const reopen = reopenKind(session, now);
+  if (session.exitCode !== -1 && !reopen) return; // finalized — stale events can't revive it
+
   const lastMs = new Date(session.lastActivityAt || session.startedAt).getTime();
   const gap = Math.max(now - lastMs, 0);
 
   const updates: Partial<Session> = {
-    // On reopen, restart the active-time clock from now so the idle gap that
-    // tripped the reaper isn't counted; the reaper already capped the duration.
-    durationSeconds: session.durationSeconds + (reopening ? 0 : activeSecondsSince(session.lastActivityAt, session.startedAt, now)),
+    // A reap already settled the duration through its active tail, so revival
+    // from one adds nothing; otherwise the gap counts as live time, capped.
+    durationSeconds: session.durationSeconds + (reopen === 'reaped' ? 0 : activeSecondsSince(session.lastActivityAt, session.startedAt, now)),
     lastActivityAt: new Date(now).toISOString(),
   };
 
-  if (reopening) {
-    // Bring the session back to live and clear the interrupted submission so the
-    // corrected final state resubmits — the server upserts on id, so it's safe.
+  if (reopen) {
+    // Back to live; clear the submission so the corrected final state
+    // resubmits — the server upserts on id, so it's safe.
     updates.exitCode = -1;
     updates.submittedAt = undefined;
   }
 
-  // Refresh git stats on reopen (to recover work shipped before the reap) and
+  // Refresh git stats on revival (to recover work shipped while closed) and
   // otherwise only past the throttle window.
-  if (reopening || gap >= GIT_REFRESH_MS) {
+  if (reopen || gap >= GIT_REFRESH_MS) {
     const stats = diffFor(session, cwd);
-    Object.assign(updates, stats);
-    updates.momentum = scoreSession({ ...stats, exitCode: -1 }, readConfig());
+    if (stats) {
+      Object.assign(updates, stats);
+      updates.momentum = scoreSession({ ...stats, exitCode: -1 }, readConfig());
+    }
   }
 
   try {
@@ -162,25 +189,27 @@ async function onSessionEnd(sessionId: string, cwd: string): Promise<void> {
   const session = getSessions().find((s) => s.id === sessionId);
   if (!session) return;
 
-  const reopening = wasReapedInterrupted(session);
-  if (session.exitCode !== -1 && !reopening) return; // unknown or already finalized normally
-
   const now = Date.now();
+  const reopen = reopenKind(session, now);
+  if (session.exitCode !== -1 && !reopen) return; // finalized — stale events can't revive it
+
   const stats = diffFor(session, cwd);
+  const updates: Partial<Session> = {
+    endedAt: new Date(now).toISOString(),
+    durationSeconds: session.durationSeconds + (reopen === 'reaped' ? 0 : activeSecondsSince(session.lastActivityAt, session.startedAt, now)),
+    // Rescore as a clean end even when the repos can't be measured (moved or
+    // deleted): the recorded stats stand, but a reaped `interrupted` must not.
+    momentum: scoreSession({ ...(stats ?? session), exitCode: 0 }, readConfig()),
+    exitCode: 0,
+    hadCleanEnd: true,
+    lastActivityAt: new Date(now).toISOString(),
+    // Clear any earlier submission so the corrected final state resubmits.
+    submittedAt: undefined,
+  };
+  if (stats) Object.assign(updates, stats);
 
   try {
-    await updateSession(sessionId, {
-      endedAt: new Date(now).toISOString(),
-      // Reopened sessions restart the clock from now (see onActivity); the reaper
-      // already capped their duration.
-      durationSeconds: session.durationSeconds + (reopening ? 0 : activeSecondsSince(session.lastActivityAt, session.startedAt, now)),
-      ...stats,
-      momentum: scoreSession({ ...stats, exitCode: 0 }, readConfig()),
-      exitCode: 0,
-      lastActivityAt: new Date(now).toISOString(),
-      // Clear any interrupted submission so the corrected final state resubmits.
-      submittedAt: undefined,
-    });
+    await updateSession(sessionId, updates);
   } catch {}
 
   await flushPendingSubmissions(1500).catch(() => {});

--- a/test/hook-reopen.test.mjs
+++ b/test/hook-reopen.test.mjs
@@ -1,0 +1,159 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+// Both must be set before any dist module loads: config.js bakes VIBE_DIR at
+// import time, and handleHook bails outright when VIBE_SESSION marks a
+// wrapper-tracked process.
+process.env.VIBE_DIR = mkdtempSync(join(tmpdir(), 'vibe-home-'));
+delete process.env.VIBE_SESSION;
+
+const { handleHook } = await import('../dist/hook.js');
+const { getSessions, updateSession, reapOrphanedSessions } = await import('../dist/db.js');
+
+function sh(cmd, cwd) {
+  execSync(cmd, { cwd, stdio: 'pipe' });
+}
+
+function initRepo(parent, name) {
+  sh(`git init -qb main ${name}`, parent);
+  const path = join(parent, name);
+  commit(path, 'init', { allowEmpty: true });
+  return path;
+}
+
+function commit(cwd, msg, { allowEmpty = false } = {}) {
+  sh(`git -c user.email=vibe@test -c user.name=vibe commit -q ${allowEmpty ? '--allow-empty ' : ''}-m ${msg}`, cwd);
+}
+
+function scratch(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'vibe-test-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+// Each test gets a clean slate so refresh paths never touch a prior test's
+// deleted scratch repos.
+function freshDb() {
+  rmSync(join(process.env.VIBE_DIR, 'sessions.json'), { force: true });
+}
+
+function hook(event, sessionId, cwd) {
+  return handleHook(event, JSON.stringify({ session_id: sessionId, cwd }));
+}
+
+function find(id) {
+  return getSessions().find((s) => s.id === id);
+}
+
+test('a spurious clean SessionEnd does not kill tracking (issue #19)', async (t) => {
+  freshDb();
+  const repo = initRepo(scratch(t), 'repo');
+  const id = randomUUID();
+
+  await hook('session-start', id, repo);
+  await hook('session-end', id, repo); // Desktop's spurious end, ~1s in
+
+  let s = find(id);
+  assert.equal(s.exitCode, 0);
+  assert.equal(s.hadCleanEnd, true);
+
+  // Mark the spurious end as submitted so the revival's resubmit-clearing is
+  // actually exercised below.
+  await updateSession(id, { submittedAt: new Date().toISOString() });
+
+  writeFileSync(join(repo, 'f.txt'), 'one\ntwo\n');
+  sh('git add f.txt', repo);
+  commit(repo, 'work');
+
+  await hook('activity', id, repo); // first prompt after the spurious end
+  s = find(id);
+  assert.equal(s.exitCode, -1); // reopened
+  assert.equal(s.commits, 1); // reopen refreshes stats immediately
+  assert.equal(s.submittedAt, undefined);
+
+  await hook('session-end', id, repo); // the real end
+  s = find(id);
+  assert.equal(s.exitCode, 0);
+  assert.equal(s.commits, 1);
+  assert.equal(s.momentum, 'progressed');
+});
+
+test('idle reap after a clean-end reopen re-finalizes clean, not interrupted', async (t) => {
+  freshDb();
+  const repo = initRepo(scratch(t), 'repo');
+  const id = randomUUID();
+
+  await hook('session-start', id, repo);
+  await hook('session-end', id, repo);
+  writeFileSync(join(repo, 'f.txt'), 'one\n');
+  sh('git add f.txt', repo);
+  commit(repo, 'work');
+  await hook('activity', id, repo); // reopen
+
+  // Age it past the inactivity timeout, with startedAt hours back so a
+  // wall-clock duration recompute would be visibly wrong.
+  const now = Date.now();
+  const lastActivityAt = new Date(now - 31 * 60_000).toISOString();
+  await updateSession(id, {
+    startedAt: new Date(now - 3 * 3_600_000).toISOString(),
+    lastActivityAt,
+    durationSeconds: 120,
+  });
+
+  await reapOrphanedSessions();
+  const s = find(id);
+  assert.equal(s.exitCode, 0);
+  assert.notEqual(s.momentum, 'interrupted');
+  assert.equal(s.durationSeconds, 120 + 30 * 60); // accumulated + capped tail, not wall-clock recomputed
+  assert.equal(s.endedAt, new Date(Date.parse(lastActivityAt) + 30 * 60_000).toISOString());
+});
+
+test('a clean end past the inactivity window is final — stale events cannot revive it', async (t) => {
+  freshDb();
+  const repo = initRepo(scratch(t), 'repo');
+  const id = randomUUID();
+
+  await hook('session-start', id, repo);
+  await hook('session-end', id, repo);
+  const submittedAt = new Date().toISOString();
+  const staleEnd = new Date(Date.now() - 2 * 3_600_000).toISOString();
+  await updateSession(id, { endedAt: staleEnd, lastActivityAt: staleEnd, submittedAt });
+
+  writeFileSync(join(repo, 'f.txt'), 'one\n');
+  sh('git add f.txt', repo);
+  commit(repo, 'later'); // belongs to whoever tracks the repo now, not this session
+
+  await hook('activity', id, repo); // e.g. `claude --resume` hours later
+  const s = find(id);
+  assert.equal(s.exitCode, 0); // still finalized
+  assert.equal(s.commits, 0); // stale baseline not re-diffed
+  assert.equal(s.submittedAt, submittedAt); // no resubmit
+});
+
+test('a session that never ended cleanly still reaps as interrupted, then reopens', async (t) => {
+  freshDb();
+  const repo = initRepo(scratch(t), 'repo');
+  const id = randomUUID();
+
+  await hook('session-start', id, repo);
+  await updateSession(id, { lastActivityAt: new Date(Date.now() - 31 * 60_000).toISOString() });
+
+  await reapOrphanedSessions();
+  let s = find(id);
+  assert.equal(s.exitCode, 1);
+  assert.equal(s.momentum, 'interrupted');
+
+  writeFileSync(join(repo, 'f.txt'), 'one\n');
+  sh('git add f.txt', repo);
+  commit(repo, 'work');
+
+  await hook('activity', id, repo); // reaper recovery path still works
+  s = find(id);
+  assert.equal(s.exitCode, -1);
+  assert.equal(s.commits, 1);
+});


### PR DESCRIPTION
## What

Desktop can fire a clean SessionEnd within seconds of SessionStart while the conversation stays open for hours. Once that end landed, every later hook event for the session bailed on the exitCode guard: the reopen path only matched reaper-interrupted sessions, and a clean end never scores interrupted. Every commit made after the phantom close was silently dropped. Reported in #19, and the reporter's root-cause analysis was spot on.

Fixes #19

## How

- `reopenKind` replaces the old reaper-only predicate. Reaper-interrupted sessions revive on any later event, however old (the lunch-break case, unchanged). Cleanly ended sessions revive only within the 30-minute inactivity window of the end. The bound matters: an unbounded revival would let a stale `claude --resume` re-diff from an old baseline and double-credit commits that other sessions already claimed.
- Sessions that ended cleanly once carry `hadCleanEnd`. If a revived session idles out again, the reaper re-finalizes it as the clean end it already had instead of downgrading it to `interrupted` and zeroing its score.
- The gap after a spurious end counts as active time on revival, as if the end never happened. Only reap revivals add nothing, since the reap already granted the active tail.
- `diffFor` returns null when no baseline repo path still exists. A moved or deleted repo reads as an all-zero diff, and a zero must not overwrite real recorded stats on revival.
- The reaper no longer recomputes duration from wall clock, which re-included every excluded idle gap when a revived session was reaped again. It extends the accumulated duration by the same capped 30-minute tail, and both branches set endedAt to the cutoff so the rescore grace window survives.
- `VIBE_DIR` is env-overridable so tests can run the full hook flow against a scratch dir. Resolved to absolute, and the data dir is chmod 0700 unconditionally.

## Known limits

A spurious end followed by more than 30 minutes of silence before the next event still drops the later work: that is the price of the double-credit bound. Nothing is retroactive for sessions already frozen by 0.5.x.

## Tests

`test/hook-reopen.test.mjs` runs the full flow through dist against a scratch VIBE_DIR: the exact issue timeline (spurious end, commit, revival, clean close), clean re-reap keeping duration and momentum, the stale-end-is-final bound, and the unchanged interrupted reap path. 11/11 passing, plus a CLI smoke replay of the issue sequence.