### PR TITLE
Add vibe config remove-tool

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import { Command } from 'commander';
 import { getSessions } from './db.js';
 import { refreshAndReap } from './rescore.js';
-import { readConfig, writeConfig, addTool } from './config.js';
+import { readConfig, writeConfig, addTool, removeTool } from './config.js';
 import { renderStatus, renderLog, renderLeaderboard } from './render.js';
 import { renderTerminalCard, writeHtmlCard } from './share.js';
 import { wrapTool } from './wrap.js';
@@ -208,6 +208,13 @@ configCmd
   .description('track a new AI CLI tool')
   .action(async (name: string) => {
     await addTool(name);
+  });
+
+configCmd
+  .command('remove-tool <name>')
+  .description('stop tracking an AI CLI tool')
+  .action((name: string) => {
+    removeTool(name);
   });
 
 configCmd

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { homedir, userInfo } from 'node:os';
 import { mkdirSync, chmodSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import chalk from 'chalk';
-import { DEFAULT_TOOLS, detectShell, appendHook } from './init.js';
+import { DEFAULT_TOOLS, detectShell, appendHook, removeHook } from './init.js';
 import { PURPLE } from './colors.js';
 
 const RED = chalk.hex('#EF4444');
@@ -62,11 +62,6 @@ export function addTool(name: string): void {
     return;
   }
 
-  if (DEFAULT_TOOLS.includes(name)) {
-    console.log(`\n  ${PURPLE('◆')} ${name} is already added by vibe init\n`);
-    return;
-  }
-
   const { rcFile } = detectShell();
 
   if (!existsSync(rcFile)) {
@@ -74,11 +69,39 @@ export function addTool(name: string): void {
     return;
   }
 
+  // A default tool is only "already added by vibe init" while its hooks are
+  // actually in the rc file — after a remove-tool it can be re-added.
   const added = appendHook(name, rcFile);
   if (added) {
     console.log(`\n  ${PURPLE('◆')} ${name} added. restart your terminal to start tracking.\n`);
+  } else if (DEFAULT_TOOLS.includes(name.toLowerCase())) {
+    console.log(`\n  ${PURPLE('◆')} ${name} is already added by vibe init\n`);
   } else {
     console.log(`\n  ${PURPLE('◆')} ${name} is already being tracked.\n`);
+  }
+}
+
+export function removeTool(name: string): void {
+  if (/\s/.test(name)) {
+    console.log(`\n  ${RED('✗')} tool name must be a single word\n`);
+    return;
+  }
+
+  const { rcFile } = detectShell();
+
+  if (!existsSync(rcFile)) {
+    console.log(`\n  ${PURPLE('◆')} nothing to remove — ${rcFile} not found\n`);
+    return;
+  }
+
+  const removed = removeHook(name, rcFile);
+  if (removed) {
+    console.log(`\n  ${PURPLE('◆')} ${name} removed. restart your terminal to stop tracking.\n`);
+    if (DEFAULT_TOOLS.includes(name.toLowerCase())) {
+      console.log(`  bring it back anytime: vibe config add-tool ${name}\n`);
+    }
+  } else {
+    console.log(`\n  ${PURPLE('◆')} ${name} is not being tracked.\n`);
   }
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -30,10 +30,28 @@ export function appendHook(tool: string, rcFile: string): boolean {
 
   if (existsSync(rcFile)) {
     const content = readFileSync(rcFile, 'utf-8');
-    if (content.includes(`vibe __wrap ${lower}`)) return false;
+    // Trailing space so `claude` doesn't match a `claudex` hook.
+    if (content.includes(`vibe __wrap ${lower} `)) return false;
   }
 
   appendFileSync(rcFile, `\n${hookLines(lower)}\n`);
+  return true;
+}
+
+export function removeHook(tool: string, rcFile: string): boolean {
+  const lower = tool.toLowerCase();
+  if (!existsSync(rcFile)) return false;
+
+  const content = readFileSync(rcFile, 'utf-8');
+  // Only hook definitions for this tool — a line that merely mentions the
+  // wrap command (a comment, an alias) is the user's, not ours.
+  const HOOK_RE = new RegExp(`^[a-zA-Z0-9_-]+\\(\\) \\{ vibe __wrap ${lower} `);
+  const filtered = content.split('\n').filter((line) => !HOOK_RE.test(line));
+
+  const cleaned = filtered.join('\n');
+  if (cleaned === content) return false;
+
+  writeFileSync(rcFile, cleaned);
   return true;
 }
 

--- a/test/shell-hooks.test.mjs
+++ b/test/shell-hooks.test.mjs
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { appendHook, removeHook } from '../dist/init.js';
+
+function scratchRc(t, content = '# my rc\nexport PATH=$PATH\n') {
+  const dir = mkdtempSync(join(tmpdir(), 'vibe-rc-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const rcFile = join(dir, '.zshrc');
+  writeFileSync(rcFile, content);
+  return rcFile;
+}
+
+test('add then remove round-trips, leaving the rest of the rc untouched', (t) => {
+  const rcFile = scratchRc(t);
+  const before = readFileSync(rcFile, 'utf-8');
+
+  assert.equal(appendHook('opencode', rcFile), true);
+  assert.match(readFileSync(rcFile, 'utf-8'), /opencode\(\) \{ vibe __wrap opencode "\$@"; \}/);
+
+  assert.equal(removeHook('opencode', rcFile), true);
+  const after = readFileSync(rcFile, 'utf-8');
+  assert.ok(!after.includes('vibe __wrap'));
+  assert.ok(after.includes('# my rc'));
+  assert.ok(after.includes('export PATH=$PATH'));
+  assert.equal(before.trim(), after.trim());
+});
+
+test('remove strips all three case variants of the hook', (t) => {
+  const rcFile = scratchRc(t);
+  appendHook('aider', rcFile);
+  const withHooks = readFileSync(rcFile, 'utf-8');
+  assert.equal(withHooks.match(/vibe __wrap aider /g).length, 3); // aider / Aider / AIDER
+
+  removeHook('aider', rcFile);
+  assert.ok(!readFileSync(rcFile, 'utf-8').includes('vibe __wrap aider'));
+});
+
+test('removing one tool leaves other tools tracked', (t) => {
+  const rcFile = scratchRc(t);
+  appendHook('opencode', rcFile);
+  appendHook('aider', rcFile);
+
+  removeHook('opencode', rcFile);
+  const after = readFileSync(rcFile, 'utf-8');
+  assert.ok(!after.includes('vibe __wrap opencode'));
+  assert.ok(after.includes('vibe __wrap aider'));
+});
+
+test('removing an untracked tool is a no-op and says so', (t) => {
+  const rcFile = scratchRc(t);
+  const before = readFileSync(rcFile, 'utf-8');
+  assert.equal(removeHook('aider', rcFile), false);
+  assert.equal(readFileSync(rcFile, 'utf-8'), before);
+});
+
+test('a tool name that prefixes another does not collide', (t) => {
+  const rcFile = scratchRc(t);
+  appendHook('claudex', rcFile);
+  // adding `claude` must not be blocked by the claudex hook
+  assert.equal(appendHook('claude', rcFile), true);
+  // and removing `claude` must not take claudex with it
+  removeHook('claude', rcFile);
+  const after = readFileSync(rcFile, 'utf-8');
+  assert.ok(!after.includes('vibe __wrap claude '));
+  assert.ok(after.includes('vibe __wrap claudex '));
+});
+
+test('a user line that merely mentions the wrap command is not ours to delete', (t) => {
+  const rcFile = scratchRc(t, '# reminder: opencode() { vibe __wrap opencode "$@"; } is what vibe adds\nalias oc=opencode\n');
+  assert.equal(removeHook('opencode', rcFile), false);
+  assert.ok(readFileSync(rcFile, 'utf-8').includes('alias oc=opencode'));
+});


### PR DESCRIPTION
Adds the missing half of add-tool. `vibe config remove-tool <name>` strips the tool's hook functions (all three case variants) from the shell rc file and leaves everything else alone.

Two small fixes that fell out of making the round trip work:
- add-tool used to refuse default tools outright, which would have made removing `claude` a one-way door. It now checks the rc file, so a removed default can be re-added, and you still get the "already added by vibe init" message when it's actually there.
- The already-tracked check now matches on a trailing space, so `claude` no longer collides with a hypothetical `claudex` hook.

Same known limitation as add-tool: bash/zsh only (#1).

Closes #23

Tests cover the round trip, case variants, multi-tool isolation, the prefix collision, and that a user's own line mentioning the wrap command is never deleted.