### PR TITLE
Add all-time total footer to vibe log

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,7 +94,7 @@ program
     await refreshAndReap();
     const sessions = getSessions();
     const recent = sessions.slice(-20).reverse();
-    console.log(renderLog(recent));
+    console.log(renderLog(recent, sessions));
   });
 
 program

--- a/src/render.ts
+++ b/src/render.ts
@@ -167,7 +167,7 @@ export function renderLeaderboard(entries: LeaderboardEntry[], webUrl: string, c
   return ['', header, '', ...rows, '', footer, ''].join('\n');
 }
 
-export function renderLog(sessions: Session[]): string {
+export function renderLog(sessions: Session[], all: Session[] = sessions): string {
   if (sessions.length === 0) {
     return '\n  no sessions recorded yet.\n';
   }
@@ -181,5 +181,11 @@ export function renderLog(sessions: Session[]): string {
     return `  ${DIM(dateStr)}  ${project}  ${duration}   ${tier}`;
   });
 
-  return ['\n', ...lines, ''].join('\n');
+  // The list shows recent sessions; the footer totals everything ever
+  // recorded, and says so — the two would otherwise read as one sum.
+  const totalSeconds = all.reduce((sum, s) => sum + s.durationSeconds, 0);
+  const shipped = all.filter((s) => s.momentum === 'shipped').length;
+  const summary = `  all time: ${formatDuration(totalSeconds)} across ${all.length} session${all.length === 1 ? '' : 's'}  ·  ${shipped} shipped`;
+
+  return ['\n', ...lines, '', `  ${DIM('─'.repeat(44))}`, summary, ''].join('\n');
 }


### PR DESCRIPTION
`vibe log` now ends with a summary line: cumulative time across every recorded session, plus session and shipped counts.

```
  26 aug  repo                      12m   progressed
  26 aug  repo                   1h 23m   shipped

  ────────────────────────────────────────────
  all time: 1h 35m across 3 sessions  ·  1 shipped
```

The list shows recent sessions while the footer totals everything, so the line says "all time" to keep the two from reading as one sum. Local display only, nothing leaves the machine.

Refs #24