### PR TITLE
feat: add Codex Desktop hook tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,41 +66,31 @@ Sessions are scored by what happened in git:
 
 ## Desktop apps
 
-`vibe init` wraps the `claude` **terminal** command. The Claude Code **Desktop** app never runs that command, so the shell wrapper can't see it. Track Desktop sessions with hooks instead:
+`vibe init` wraps the **terminal** commands. The Claude Code and Codex **Desktop** apps never run those commands, so the shell wrapper can't see them. Track Desktop sessions with hooks instead:
 
 ```
 vibe hooks install
 ```
 
-This registers session hooks in `~/.claude/settings.json` — the same settings the Desktop app reads. From then on, every Desktop session is recorded and shows up in `vibe status`, `vibe log`, `vibe share`, and the leaderboard, exactly like a terminal session.
+One command covers both apps. It registers session hooks in `~/.claude/settings.json` and `~/.codex/hooks.json` for whichever apps are installed, skips the ones that aren't, and never touches hooks it didn't create. From then on, every Desktop session is recorded and shows up in `vibe status`, `vibe log`, `vibe share`, and the leaderboard, exactly like a terminal session.
 
-Nothing else to run: Claude Code hot-reloads the settings, so just open a new Desktop session. Duration is measured the same way as the terminal — active coding time, with idle gaps over 30 minutes excluded.
+- **Claude Code** hot-reloads its settings: just open a new Desktop session.
+- **Codex** asks you to trust new hooks once: run `/hooks` in Codex, review the commands, then open a new session. Needs a Codex build from May 2026 or later (when hooks became generally available). Tested on macOS and Linux; Windows isn't supported yet.
+
+Duration is measured the same way as the terminal: active coding time, with idle gaps over 30 minutes excluded.
 
 **Working across several repos?** Start the session wherever you like. If that directory isn't a repo itself, vibetime picks up the repos sitting directly inside it and measures all of them, so a session that touches `api/` and `web/` is scored on both. A directory with no repos in or under it isn't tracked — there'd be nothing to measure.
 
-If you use **both** the terminal wrapper and Desktop hooks, terminal `claude` sessions are counted once, not twice — the hooks stand down when the shell wrapper is already tracking.
-
-### Codex Desktop
-
-Codex Desktop uses the same session engine through Codex lifecycle hooks:
-
-```
-vibe hooks install codex
-```
-
-This adds Vibetime's hooks to `~/.codex/hooks.json` without replacing your existing Codex hooks. In Codex, run `/hooks`, review the commands, and trust the configuration once. Then open a new Codex session. It will appear as `codex` in `vibe status`, `vibe log`, `vibe share`, and the leaderboard.
-
-Vibetime measures the git changes made while that Codex session is active. Codex sends activity events as you prompt it and use tools, then a session-end event when the session closes or is archived. Idle gaps over 30 minutes are excluded, just like Claude Desktop tracking.
+If you use **both** the terminal wrapper and Desktop hooks, terminal sessions are counted once, not twice — the hooks stand down when the shell wrapper is already tracking.
 
 > **Why hooks use absolute paths** — the Desktop app, when launched from the Dock, doesn't inherit your shell `PATH`, so a bare `vibe` wouldn't resolve. `vibe hooks install` pins the absolute path to Node and the CLI so tracking works regardless of how Desktop is launched.
 >
-> If you switch Node versions (e.g. an `nvm` upgrade) and remove the old one, re-run the relevant install command so the pinned path points at your current Node. Codex will ask you to review the changed command again.
+> If you switch Node versions (e.g. an `nvm` upgrade) and remove the old one, re-run `vibe hooks install` so the pinned path points at your current Node. Codex will ask you to review the changed commands again.
 
 Stop tracking Desktop at any time:
 
 ```
-vibe hooks uninstall         # Claude Code Desktop
-vibe hooks uninstall codex   # Codex Desktop
+vibe hooks uninstall
 ```
 
 ## Leaderboard (opt-in)
@@ -155,10 +145,8 @@ vibe leaderboard             shipped sessions, last 7 days
 vibe config show             current settings
 vibe config set handle <name> set your @handle (shown on share cards)
 vibe config add-tool <name>  track a new AI CLI tool
-vibe hooks install           track Claude Code Desktop sessions
-vibe hooks install codex     track Codex Desktop sessions
-vibe hooks uninstall         stop tracking Claude Code Desktop
-vibe hooks uninstall codex   stop tracking Codex Desktop
+vibe hooks install           track Claude Code + Codex Desktop sessions
+vibe hooks uninstall         stop tracking Desktop sessions
 vibe uninstall               remove shell hooks
 ```
 
@@ -168,12 +156,11 @@ Sessions belong to the day they started — a session that runs past midnight ap
 
 ```
 vibe uninstall
-vibe hooks uninstall         # if you tracked Claude Code Desktop
-vibe hooks uninstall codex   # if you tracked Codex Desktop
+vibe hooks uninstall   # if you tracked Desktop sessions
 npm uninstall -g vibetime-cli
 ```
 
-`vibe uninstall` removes all shell hooks from your rc file. The two `vibe hooks uninstall` commands remove Vibetime's hooks from `~/.claude/settings.json` and `~/.codex/hooks.json` while preserving other hooks. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
+`vibe uninstall` removes all shell hooks from your rc file. `vibe hooks uninstall` removes Vibetime's hooks from `~/.claude/settings.json` and `~/.codex/hooks.json` while preserving other hooks. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ vibe init
 source ~/.zshrc   # or ~/.bashrc — or restart your terminal
 ```
 
-Adds shell hooks that wrap `claude`, `codex`, and `gemini`. The tools work exactly the same — Vibetime tracks your git state while you code and prints the endcard when you're done.
+One command sets up everything: shell hooks that wrap `claude`, `codex`, and `gemini` in the terminal, plus desktop session hooks for the Claude Code and Codex apps you have installed (see [Desktop apps](#desktop-apps)). The tools work exactly the same — Vibetime tracks your git state while you code and prints the endcard when you're done.
 
 **Fish shell** — `vibe init` writes bash/zsh syntax. Fish users should add hooks manually to `~/.config/fish/config.fish`:
 
@@ -66,13 +66,13 @@ Sessions are scored by what happened in git:
 
 ## Desktop apps
 
-`vibe init` wraps the **terminal** commands. The Claude Code and Codex **Desktop** apps never run those commands, so the shell wrapper can't see them. Track Desktop sessions with hooks instead:
+The Claude Code and Codex **Desktop** apps never run the wrapped terminal commands, so the shell wrapper can't see them. Vibetime tracks them through session hooks instead — `vibe init` sets these up automatically. If you ran `vibe init` before desktop support existed, either re-run it or use:
 
 ```
 vibe hooks install
 ```
 
-One command covers both apps. It registers session hooks in `~/.claude/settings.json` and `~/.codex/hooks.json` for whichever apps are installed, skips the ones that aren't, and never touches hooks it didn't create. From then on, every Desktop session is recorded and shows up in `vibe status`, `vibe log`, `vibe share`, and the leaderboard, exactly like a terminal session.
+Either way it registers session hooks in `~/.claude/settings.json` and `~/.codex/hooks.json` for whichever apps are installed, skips the ones that aren't, and never touches hooks it didn't create. From then on, every Desktop session is recorded and shows up in `vibe status`, `vibe log`, `vibe share`, and the leaderboard, exactly like a terminal session.
 
 - **Claude Code** hot-reloads its settings: just open a new Desktop session.
 - **Codex** asks you to trust new hooks once: run `/hooks` in Codex, review the commands, then open a new session. Needs a Codex build from May 2026 or later (when hooks became generally available). Tested on macOS and Linux; Windows isn't supported yet.
@@ -147,7 +147,7 @@ vibe config set handle <name> set your @handle (shown on share cards)
 vibe config add-tool <name>  track a new AI CLI tool
 vibe hooks install           track Claude Code + Codex Desktop sessions
 vibe hooks uninstall         stop tracking Desktop sessions
-vibe uninstall               remove shell hooks
+vibe uninstall               remove shell hooks and desktop hooks
 ```
 
 Sessions belong to the day they started — a session that runs past midnight appears under the previous day.
@@ -156,11 +156,10 @@ Sessions belong to the day they started — a session that runs past midnight ap
 
 ```
 vibe uninstall
-vibe hooks uninstall   # if you tracked Desktop sessions
 npm uninstall -g vibetime-cli
 ```
 
-`vibe uninstall` removes all shell hooks from your rc file. `vibe hooks uninstall` removes Vibetime's hooks from `~/.claude/settings.json` and `~/.codex/hooks.json` while preserving other hooks. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
+`vibe uninstall` removes everything `vibe init` set up: the shell hooks in your rc file and Vibetime's desktop hooks in `~/.claude/settings.json` and `~/.codex/hooks.json`, preserving hooks it didn't create. To stop desktop tracking alone, run `vibe hooks uninstall`. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Sessions are scored by what happened in git:
 
 **How duration works** — Vibetime polls your git state every 30 seconds. If no file changes, commits, or staging activity are detected for 30 minutes, the idle time is excluded from your session duration. Laptop sleep and background idle are automatically handled. Non-git projects use wall-clock time.
 
-## Claude Code Desktop
+## Desktop apps
 
 `vibe init` wraps the `claude` **terminal** command. The Claude Code **Desktop** app never runs that command, so the shell wrapper can't see it. Track Desktop sessions with hooks instead:
 
@@ -80,14 +80,27 @@ Nothing else to run: Claude Code hot-reloads the settings, so just open a new De
 
 If you use **both** the terminal wrapper and Desktop hooks, terminal `claude` sessions are counted once, not twice — the hooks stand down when the shell wrapper is already tracking.
 
+### Codex Desktop
+
+Codex Desktop uses the same session engine through Codex lifecycle hooks:
+
+```
+vibe hooks install codex
+```
+
+This adds Vibetime's hooks to `~/.codex/hooks.json` without replacing your existing Codex hooks. In Codex, run `/hooks`, review the commands, and trust the configuration once. Then open a new Codex session. It will appear as `codex` in `vibe status`, `vibe log`, `vibe share`, and the leaderboard.
+
+Vibetime measures the git changes made while that Codex session is active. Codex sends activity events as you prompt it and use tools, then a session-end event when the session closes or is archived. Idle gaps over 30 minutes are excluded, just like Claude Desktop tracking.
+
 > **Why hooks use absolute paths** — the Desktop app, when launched from the Dock, doesn't inherit your shell `PATH`, so a bare `vibe` wouldn't resolve. `vibe hooks install` pins the absolute path to Node and the CLI so tracking works regardless of how Desktop is launched.
 >
-> If you switch Node versions (e.g. an `nvm` upgrade) and remove the old one, re-run `vibe hooks install` so the pinned path points at your current Node.
+> If you switch Node versions (e.g. an `nvm` upgrade) and remove the old one, re-run the relevant install command so the pinned path points at your current Node. Codex will ask you to review the changed command again.
 
 Stop tracking Desktop at any time:
 
 ```
-vibe hooks uninstall
+vibe hooks uninstall         # Claude Code Desktop
+vibe hooks uninstall codex   # Codex Desktop
 ```
 
 ## Leaderboard (opt-in)
@@ -143,7 +156,9 @@ vibe config show             current settings
 vibe config set handle <name> set your @handle (shown on share cards)
 vibe config add-tool <name>  track a new AI CLI tool
 vibe hooks install           track Claude Code Desktop sessions
+vibe hooks install codex     track Codex Desktop sessions
 vibe hooks uninstall         stop tracking Claude Code Desktop
+vibe hooks uninstall codex   stop tracking Codex Desktop
 vibe uninstall               remove shell hooks
 ```
 
@@ -153,11 +168,12 @@ Sessions belong to the day they started — a session that runs past midnight ap
 
 ```
 vibe uninstall
-vibe hooks uninstall   # if you tracked Claude Code Desktop
+vibe hooks uninstall         # if you tracked Claude Code Desktop
+vibe hooks uninstall codex   # if you tracked Codex Desktop
 npm uninstall -g vibetime-cli
 ```
 
-`vibe uninstall` removes all shell hooks from your rc file, and `vibe hooks uninstall` removes the Claude Code Desktop hooks from `~/.claude/settings.json`. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
+`vibe uninstall` removes all shell hooks from your rc file. The two `vibe hooks uninstall` commands remove Vibetime's hooks from `~/.claude/settings.json` and `~/.codex/hooks.json` while preserving other hooks. Your session data in `~/.vibe/` is preserved — delete it manually if you want a clean removal.
 
 ## Privacy
 
@@ -165,7 +181,7 @@ Vibetime has no telemetry and no account by default. Everything stays on your ma
 
 It reads **git metadata only** — commit counts, line counts, file counts. It never reads file contents, environment variables, API keys, or anything you type into the wrapped tool. The AI CLI's stdin/stdout are passed straight through via `spawn` with `stdio: 'inherit'`.
 
-The Claude Code Desktop hooks are held to the same standard: they read only the session id and working directory from the hook payload — never the transcript, your prompts, or the model's output — and derive the same git metadata from there.
+The Claude Code and Codex Desktop hooks are held to the same standard: they read only the session id and working directory from the hook payload — never the transcript, your prompts, or the model's output — and derive the same git metadata from there.
 
 All data is stored locally in `~/.vibe/`. If you've signed in to the leaderboard, see the section above for the exact fields submitted.
 

--- a/src/claude-hooks.ts
+++ b/src/claude-hooks.ts
@@ -10,6 +10,11 @@ const RED = chalk.hex('#EF4444');
 const CLAUDE_DIR = join(homedir(), '.claude');
 const SETTINGS_PATH = join(CLAUDE_DIR, 'settings.json');
 
+// Claude Code creates ~/.claude on first run, so its presence is the install signal.
+export function claudePresent(): boolean {
+  return existsSync(CLAUDE_DIR);
+}
+
 // Claude Code hook event -> the internal `vibe __hook <event>` we dispatch to.
 // SessionStart opens the session, SessionEnd closes and submits it, and the
 // per-turn events keep the active-time accumulator honest between the two.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,8 @@ import { renderTerminalCard, writeHtmlCard } from './share.js';
 import { wrapTool } from './wrap.js';
 import { initShellHooks, removeShellHooks } from './init.js';
 import { installClaudeHooks, removeClaudeHooks } from './claude-hooks.js';
-import { handleHook } from './hook.js';
+import { installCodexHooks, removeCodexHooks } from './codex-hooks.js';
+import { handleHook, type HookTool } from './hook.js';
 import { login, logout, readAuth } from './auth.js';
 import { fetchLeaderboard } from './leaderboard.js';
 import { flushPendingSubmissions } from './submit.js';
@@ -50,17 +51,27 @@ program
 
 const hooksCmd = program
   .command('hooks')
-  .description('track Claude Code Desktop via session hooks');
+  .description('track desktop coding sessions via lifecycle hooks');
 
 hooksCmd
   .command('install')
-  .description('track Claude Code Desktop sessions (no shell wrapper needed)')
-  .action(installClaudeHooks);
+  .argument('[tool]', 'claude | codex', 'claude')
+  .description('track Claude Code or Codex Desktop sessions')
+  .action((tool: string) => {
+    if (tool === 'claude') return installClaudeHooks();
+    if (tool === 'codex') return installCodexHooks();
+    console.log(`\n  ${RED('✗')} vibe: hooks tool must be "claude" or "codex"\n`);
+  });
 
 hooksCmd
   .command('uninstall')
-  .description('stop tracking Claude Code Desktop sessions')
-  .action(removeClaudeHooks);
+  .argument('[tool]', 'claude | codex', 'claude')
+  .description('stop tracking Claude Code or Codex Desktop sessions')
+  .action((tool: string) => {
+    if (tool === 'claude') return removeClaudeHooks();
+    if (tool === 'codex') return removeCodexHooks();
+    console.log(`\n  ${RED('✗')} vibe: hooks tool must be "claude" or "codex"\n`);
+  });
 
 program
   .command('status')
@@ -233,18 +244,22 @@ program
     await wrapTool(tool, args);
   });
 
-// Invoked by Claude Code hooks with the event payload on stdin. Must stay silent
-// on stdout (SessionStart stdout is fed to the model) and always exit cleanly so
-// it can never interfere with the user's session.
+// Invoked by Claude Code or Codex hooks with the event payload on stdin. It stays
+// silent unless Codex requires an empty JSON response, and always exits cleanly
+// so tracking can never interfere with the user's session.
 program
   .command('__hook', { hidden: true })
   .argument('<event>', 'session-start | activity | session-end')
+  .option('--tool <tool>', 'claude | codex', 'claude')
+  .option('--respond-json', 'write an empty JSON hook response')
   .helpOption(false)
-  .action(async (event: string) => {
+  .action(async (event: string, opts: { tool: string; respondJson?: boolean }) => {
     try {
-      await handleHook(event, await readStdin());
+      const tool: HookTool = opts.tool === 'codex' ? 'codex' : 'claude';
+      await handleHook(event, await readStdin(), tool);
     } catch {}
-    process.exit(0);
+    if (opts.respondJson) process.stdout.write('{}\n');
+    process.exitCode = 0;
   });
 
 function readStdin(): Promise<string> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,8 +8,8 @@ import { renderStatus, renderLog, renderLeaderboard } from './render.js';
 import { renderTerminalCard, writeHtmlCard } from './share.js';
 import { wrapTool } from './wrap.js';
 import { initShellHooks, removeShellHooks } from './init.js';
-import { installClaudeHooks, removeClaudeHooks } from './claude-hooks.js';
-import { installCodexHooks, removeCodexHooks } from './codex-hooks.js';
+import { installClaudeHooks, removeClaudeHooks, claudePresent } from './claude-hooks.js';
+import { installCodexHooks, removeCodexHooks, codexPresent } from './codex-hooks.js';
 import { handleHook, type HookTool } from './hook.js';
 import { login, logout, readAuth } from './auth.js';
 import { fetchLeaderboard } from './leaderboard.js';
@@ -53,24 +53,31 @@ const hooksCmd = program
   .command('hooks')
   .description('track desktop coding sessions via lifecycle hooks');
 
+// One command covers every desktop app, mirroring how `vibe init` wraps every
+// terminal tool. Presence-gated so we never write config for an app that was
+// never installed.
 hooksCmd
   .command('install')
-  .argument('[tool]', 'claude | codex', 'claude')
-  .description('track Claude Code or Codex Desktop sessions')
-  .action((tool: string) => {
-    if (tool === 'claude') return installClaudeHooks();
-    if (tool === 'codex') return installCodexHooks();
-    console.log(`\n  ${RED('✗')} vibe: hooks tool must be "claude" or "codex"\n`);
+  .description('track Claude Code and Codex Desktop sessions')
+  .action(() => {
+    const claude = claudePresent();
+    const codex = codexPresent();
+    if (!claude && !codex) {
+      console.log(`\n  ${RED('✗')} vibe: no desktop apps found (looked for ~/.claude and ~/.codex)\n`);
+      return;
+    }
+    if (claude) installClaudeHooks();
+    else console.log(`\n  ${PURPLE('◆')} claude code not found, skipped\n`);
+    if (codex) installCodexHooks();
+    else console.log(`\n  ${PURPLE('◆')} codex not found, skipped\n`);
   });
 
 hooksCmd
   .command('uninstall')
-  .argument('[tool]', 'claude | codex', 'claude')
-  .description('stop tracking Claude Code or Codex Desktop sessions')
-  .action((tool: string) => {
-    if (tool === 'claude') return removeClaudeHooks();
-    if (tool === 'codex') return removeCodexHooks();
-    console.log(`\n  ${RED('✗')} vibe: hooks tool must be "claude" or "codex"\n`);
+  .description('stop tracking Claude Code and Codex Desktop sessions')
+  .action(() => {
+    removeClaudeHooks();
+    removeCodexHooks();
   });
 
 program
@@ -244,9 +251,10 @@ program
     await wrapTool(tool, args);
   });
 
-// Invoked by Claude Code or Codex hooks with the event payload on stdin. It stays
-// silent unless Codex requires an empty JSON response, and always exits cleanly
-// so tracking can never interfere with the user's session.
+// Invoked by Claude Code or Codex hooks with the event payload on stdin. Must stay
+// silent on stdout (SessionStart stdout is fed to the model) except for the codex
+// Stop response, and always exit the moment the work is done — a lingering handle
+// (e.g. a submit's keep-alive socket) must never hold the host's hook slot open.
 program
   .command('__hook', { hidden: true })
   .argument('<event>', 'session-start | activity | session-end')
@@ -258,8 +266,8 @@ program
       const tool: HookTool = opts.tool === 'codex' ? 'codex' : 'claude';
       await handleHook(event, await readStdin(), tool);
     } catch {}
-    if (opts.respondJson) process.stdout.write('{}\n');
-    process.exitCode = 0;
+    if (opts.respondJson) process.stdout.write('{}\n', () => process.exit(0));
+    else process.exit(0);
   });
 
 function readStdin(): Promise<string> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,38 +39,48 @@ program
   .version(version)
   .enablePositionalOptions();
 
+// One pass covers every desktop app, mirroring how `vibe init` wraps every
+// terminal tool. Presence-gated so we never write config for an app that was
+// never installed. During init, absent apps are skipped silently — the noise
+// is only useful when the user asked for desktop hooks by name.
+function installDesktopHooks(explicit: boolean): void {
+  const claude = claudePresent();
+  const codex = codexPresent();
+  if (!claude && !codex) {
+    if (explicit) console.log(`\n  ${RED('✗')} vibe: no desktop apps found (looked for ~/.claude and ~/.codex)\n`);
+    return;
+  }
+  if (claude) installClaudeHooks();
+  else if (explicit) console.log(`\n  ${PURPLE('◆')} claude code not found, skipped\n`);
+  if (codex) installCodexHooks();
+  else if (explicit) console.log(`\n  ${PURPLE('◆')} codex not found, skipped\n`);
+}
+
 program
   .command('init')
-  .description('set up shell hooks for session tracking')
-  .action(initShellHooks);
+  .description('set up session tracking: shell wrapper + desktop hooks')
+  .action(() => {
+    initShellHooks();
+    installDesktopHooks(false);
+  });
 
 program
   .command('uninstall')
-  .description('remove shell hooks')
-  .action(removeShellHooks);
+  .description('remove shell hooks and desktop hooks')
+  .action(() => {
+    removeShellHooks();
+    removeClaudeHooks();
+    removeCodexHooks();
+  });
 
 const hooksCmd = program
   .command('hooks')
   .description('track desktop coding sessions via lifecycle hooks');
 
-// One command covers every desktop app, mirroring how `vibe init` wraps every
-// terminal tool. Presence-gated so we never write config for an app that was
-// never installed.
 hooksCmd
   .command('install')
   .description('track Claude Code and Codex Desktop sessions')
-  .action(() => {
-    const claude = claudePresent();
-    const codex = codexPresent();
-    if (!claude && !codex) {
-      console.log(`\n  ${RED('✗')} vibe: no desktop apps found (looked for ~/.claude and ~/.codex)\n`);
-      return;
-    }
-    if (claude) installClaudeHooks();
-    else console.log(`\n  ${PURPLE('◆')} claude code not found, skipped\n`);
-    if (codex) installCodexHooks();
-    else console.log(`\n  ${PURPLE('◆')} codex not found, skipped\n`);
-  });
+  .action(() => installDesktopHooks(true));
 
 hooksCmd
   .command('uninstall')

--- a/src/codex-hooks.ts
+++ b/src/codex-hooks.ts
@@ -38,6 +38,12 @@ function defaultHooksPath(): string {
   return join(codexDir, 'hooks.json');
 }
 
+// Codex creates its config dir on first run, so its presence is the install signal.
+// Installing hooks without it would litter ~/.codex on machines that never ran Codex.
+export function codexPresent(): boolean {
+  return existsSync(dirname(defaultHooksPath()));
+}
+
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }

--- a/src/codex-hooks.ts
+++ b/src/codex-hooks.ts
@@ -1,0 +1,172 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import chalk from 'chalk';
+import { PURPLE } from './colors.js';
+
+const RED = chalk.hex('#EF4444');
+
+type HookEvent = 'session-start' | 'activity' | 'session-end';
+
+const EVENT_MAP: Record<string, HookEvent> = {
+  SessionStart: 'session-start',
+  UserPromptSubmit: 'activity',
+  PostToolUse: 'activity',
+  Stop: 'activity',
+  SessionEnd: 'session-end',
+};
+
+interface HookCommand {
+  type: 'command';
+  command: string;
+  timeout?: number;
+}
+
+interface HookGroup {
+  matcher?: string;
+  hooks: HookCommand[];
+}
+
+export interface CodexHooksConfig {
+  hooks?: Record<string, HookGroup[]>;
+  [key: string]: unknown;
+}
+
+function defaultHooksPath(): string {
+  const codexDir = process.env.CODEX_HOME || join(homedir(), '.codex');
+  return join(codexDir, 'hooks.json');
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function codexHookCommand(event: HookEvent, hookEventName: string): string {
+  // Codex Desktop launched from the Dock may not inherit the shell PATH, so pin
+  // the current Node executable and this installed CLI entry point.
+  const cli = fileURLToPath(new URL('./cli.js', import.meta.url));
+  const jsonResponse = hookEventName === 'Stop' ? ' --respond-json' : '';
+  return `${shellQuote(process.execPath)} ${shellQuote(cli)} __hook ${event} --tool codex${jsonResponse}`;
+}
+
+function isCodexVibeHook(group: HookGroup): boolean {
+  return Array.isArray(group?.hooks) && group.hooks.some(
+    (hook) => typeof hook?.command === 'string'
+      && hook.command.includes('__hook')
+      && hook.command.includes('--tool codex'),
+  );
+}
+
+export function mergeCodexHooks(config: CodexHooksConfig): {
+  config: CodexHooksConfig;
+  added: number;
+  existing: number;
+  updated: number;
+} {
+  const hooks = config.hooks ?? {};
+  let added = 0;
+  let existing = 0;
+  let updated = 0;
+
+  for (const [codexEvent, vibeEvent] of Object.entries(EVENT_MAP)) {
+    const list = Array.isArray(hooks[codexEvent]) ? hooks[codexEvent] : [];
+    const group: HookGroup = {
+      hooks: [{
+        type: 'command',
+        command: codexHookCommand(vibeEvent, codexEvent),
+        // Codex waits at most three seconds for SessionEnd hooks.
+        timeout: codexEvent === 'SessionEnd' ? 3 : 10,
+      }],
+    };
+    if (codexEvent === 'PostToolUse') group.matcher = '';
+
+    const ours = list.filter(isCodexVibeHook);
+    if (ours.length > 0) {
+      existing++;
+      if (ours.length !== 1 || JSON.stringify(ours[0]) !== JSON.stringify(group)) updated++;
+      hooks[codexEvent] = [...list.filter((candidate) => !isCodexVibeHook(candidate)), group];
+    } else {
+      list.push(group);
+      hooks[codexEvent] = list;
+      added++;
+    }
+  }
+
+  config.hooks = hooks;
+  return { config, added, existing, updated };
+}
+
+export function stripCodexHooks(config: CodexHooksConfig): { config: CodexHooksConfig; removed: number } {
+  if (!config.hooks) return { config, removed: 0 };
+
+  let removed = 0;
+  for (const event of Object.keys(config.hooks)) {
+    const list = config.hooks[event];
+    if (!Array.isArray(list)) continue;
+    const kept = list.filter((group) => {
+      const ours = isCodexVibeHook(group);
+      if (ours) removed++;
+      return !ours;
+    });
+    if (kept.length > 0) config.hooks[event] = kept;
+    else delete config.hooks[event];
+  }
+  if (Object.keys(config.hooks).length === 0) delete config.hooks;
+
+  return { config, removed };
+}
+
+function readConfig(path: string): CodexHooksConfig | null {
+  if (!existsSync(path)) return {};
+  try {
+    const raw = readFileSync(path, 'utf-8').trim();
+    return raw ? (JSON.parse(raw) as CodexHooksConfig) : {};
+  } catch {
+    return null;
+  }
+}
+
+function writeConfig(path: string, config: CodexHooksConfig): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+}
+
+export function installCodexHooks(path = defaultHooksPath()): void {
+  const current = readConfig(path);
+  if (current === null) {
+    console.log(`\n  ${RED('✗')} vibe: ${path} is not valid JSON — fix it and re-run\n`);
+    return;
+  }
+
+  const { config, added, existing, updated } = mergeCodexHooks(current);
+  writeConfig(path, config);
+
+  if (added === 0 && updated === 0) {
+    console.log(`\n  ${PURPLE('◆')} codex desktop tracking already installed\n`);
+    return;
+  }
+
+  const action = added > 0 ? 'installed' : 'updated';
+  console.log(`\n  ${PURPLE('◆')} codex desktop tracking ${action} in ${path}\n`);
+  console.log(`  In Codex, run /hooks, review the commands, and trust the configuration.`);
+  console.log(`  Then open a new Codex session to start tracking.\n`);
+  if (existing > 0) console.log(`  (${existing} event${existing === 1 ? '' : 's'} were already wired up)\n`);
+}
+
+export function removeCodexHooks(path = defaultHooksPath()): void {
+  const current = readConfig(path);
+  if (current === null) {
+    console.log(`\n  ${RED('✗')} vibe: ${path} is not valid JSON — fix it and re-run\n`);
+    return;
+  }
+
+  const { config, removed } = stripCodexHooks(current);
+  if (removed === 0) {
+    console.log(`\n  ${PURPLE('◆')} no codex desktop hooks found\n`);
+    return;
+  }
+
+  writeConfig(path, config);
+  console.log(`\n  ${PURPLE('◆')} codex desktop tracking removed from ${path}\n`);
+}

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -6,9 +6,9 @@ import { readConfig } from './config.js';
 import { scoreSession } from './score.js';
 import { flushPendingSubmissions } from './submit.js';
 
-// Claude Code delivers a JSON payload on stdin to every hook command. We read
-// only the fields below — never the transcript contents — so hook-tracked
-// sessions stay within vibetime's "git metadata only" privacy model.
+// Claude Code and Codex deliver a JSON payload on stdin to every hook command.
+// We read only the fields below — never the transcript contents — so hook-
+// tracked sessions stay within vibetime's "git metadata only" privacy model.
 interface HookInput {
   session_id?: string;
   cwd?: string;
@@ -24,6 +24,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const GIT_REFRESH_MS = 15_000;
 
 type HookEvent = 'session-start' | 'activity' | 'session-end';
+export type HookTool = 'claude' | 'codex';
 
 const EMPTY_STATS: GitDiffStats = { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
 
@@ -80,10 +81,10 @@ function reopenKind(session: Session, now: number): 'reaped' | 'clean' | null {
   return null;
 }
 
-export async function handleHook(event: string, raw: string): Promise<void> {
+export async function handleHook(event: string, raw: string, tool: HookTool = 'claude'): Promise<void> {
   // The shell wrapper (`vibe __wrap`) already tracks its child session end to
-  // end and marks it with VIBE_SESSION=1. Claude Code fires these hooks inside
-  // that wrapped process too, so bail out to avoid double-counting.
+  // end and marks it with VIBE_SESSION=1. Desktop hooks may also fire inside
+  // that wrapped process, so bail out to avoid double-counting.
   if (process.env.VIBE_SESSION === '1') return;
 
   let input: HookInput;
@@ -99,7 +100,7 @@ export async function handleHook(event: string, raw: string): Promise<void> {
 
   switch (event as HookEvent) {
     case 'session-start':
-      return onSessionStart(sessionId, cwd);
+      return onSessionStart(sessionId, cwd, tool);
     case 'activity':
       return onActivity(sessionId, cwd);
     case 'session-end':
@@ -107,11 +108,11 @@ export async function handleHook(event: string, raw: string): Promise<void> {
   }
 }
 
-async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
+async function onSessionStart(sessionId: string, cwd: string, tool: HookTool): Promise<void> {
   await refreshAndReap();
 
-  // SessionStart also fires on resume/clear/compact — key off the Claude
-  // session id so a session is only opened once.
+  // SessionStart can also fire when an existing conversation is resumed — key
+  // off the provider's session id so a session is only opened once.
   if (getSessions().some((s) => s.id === sessionId)) return;
 
   // The repo the session started in, or — when it started from a directory that
@@ -127,7 +128,7 @@ async function onSessionStart(sessionId: string, cwd: string): Promise<void> {
 
   const session: Session = {
     id: sessionId,
-    tool: 'claude',
+    tool,
     ...describeRepos(repos, cwd),
     startedAt,
     endedAt: startedAt,

--- a/test/codex-hooks.test.mjs
+++ b/test/codex-hooks.test.mjs
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const {
+  installCodexHooks,
+  mergeCodexHooks,
+  stripCodexHooks,
+} = await import('../dist/codex-hooks.js');
+
+function scratch(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'vibe-codex-hooks-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function otherHook(command = 'notify-send done') {
+  return { hooks: [{ type: 'command', command, timeout: 5 }] };
+}
+
+test('Codex hooks merge non-destructively and are idempotent', () => {
+  const unrelated = otherHook();
+  const config = {
+    description: 'keep me',
+    hooks: {
+      Stop: [unrelated],
+      PreToolUse: [otherHook('policy-check')],
+    },
+  };
+
+  const first = mergeCodexHooks(config);
+  assert.equal(first.added, 5);
+  assert.equal(first.existing, 0);
+  assert.equal(first.config.description, 'keep me');
+  assert.equal(first.config.hooks.Stop[0], unrelated);
+  assert.equal(first.config.hooks.PreToolUse.length, 1);
+
+  const codexGroups = Object.fromEntries(
+    ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'Stop', 'SessionEnd'].map((event) => [
+      event,
+      first.config.hooks[event].find((group) => group.hooks.some((hook) => hook.command.includes('--tool codex'))),
+    ]),
+  );
+
+  assert.equal(codexGroups.PostToolUse.matcher, '');
+  assert.equal('matcher' in codexGroups.UserPromptSubmit, false);
+  assert.match(codexGroups.Stop.hooks[0].command, /__hook activity --tool codex --respond-json$/);
+  assert.equal(codexGroups.Stop.hooks[0].timeout, 10);
+  assert.equal(codexGroups.SessionEnd.hooks[0].timeout, 3);
+
+  const second = mergeCodexHooks(first.config);
+  assert.equal(second.added, 0);
+  assert.equal(second.existing, 5);
+  assert.equal(second.updated, 0);
+});
+
+test('reinstall refreshes stale commands without duplicating hooks', () => {
+  const first = mergeCodexHooks({});
+  const sessionStart = first.config.hooks.SessionStart.find((group) =>
+    group.hooks.some((hook) => hook.command.includes('--tool codex')),
+  );
+  sessionStart.hooks[0].command = "'/old/node' '/old/vibe' __hook session-start --tool codex";
+
+  const second = mergeCodexHooks(first.config);
+  const vibeGroups = second.config.hooks.SessionStart.filter((group) =>
+    group.hooks.some((hook) => hook.command.includes('--tool codex')),
+  );
+
+  assert.equal(second.added, 0);
+  assert.equal(second.updated, 1);
+  assert.equal(vibeGroups.length, 1);
+  assert.doesNotMatch(vibeGroups[0].hooks[0].command, /old\/node/);
+});
+
+test('Codex hook removal preserves unrelated hooks and top-level settings', () => {
+  const config = mergeCodexHooks({
+    description: 'keep me',
+    hooks: { Stop: [otherHook()] },
+  }).config;
+
+  const { config: stripped, removed } = stripCodexHooks(config);
+  assert.equal(removed, 5);
+  assert.equal(stripped.description, 'keep me');
+  assert.deepEqual(stripped.hooks, { Stop: [otherHook()] });
+});
+
+test('installer never clobbers an invalid hooks.json', (t) => {
+  const path = join(scratch(t), 'hooks.json');
+  writeFileSync(path, '{ definitely not json\n');
+
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    installCodexHooks(path);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(readFileSync(path, 'utf8'), '{ definitely not json\n');
+});
+
+test('Codex Stop hook returns the required JSON response', () => {
+  const cli = new URL('../dist/cli.js', import.meta.url);
+  const result = spawnSync(process.execPath, [cli.pathname, '__hook', 'activity', '--tool', 'codex', '--respond-json'], {
+    input: '{}',
+    encoding: 'utf8',
+    env: { ...process.env, VIBE_SESSION: '1' },
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, '{}\n');
+  assert.equal(result.stderr, '');
+});

--- a/test/hook-reopen.test.mjs
+++ b/test/hook-reopen.test.mjs
@@ -42,8 +42,8 @@ function freshDb() {
   rmSync(join(process.env.VIBE_DIR, 'sessions.json'), { force: true });
 }
 
-function hook(event, sessionId, cwd) {
-  return handleHook(event, JSON.stringify({ session_id: sessionId, cwd }));
+function hook(event, sessionId, cwd, tool) {
+  return handleHook(event, JSON.stringify({ session_id: sessionId, cwd }), tool);
 }
 
 function find(id) {
@@ -156,4 +156,17 @@ test('a session that never ended cleanly still reaps as interrupted, then reopen
   s = find(id);
   assert.equal(s.exitCode, -1);
   assert.equal(s.commits, 1);
+});
+
+test('Codex hook sessions are labelled separately from Claude sessions', async (t) => {
+  freshDb();
+  const repo = initRepo(scratch(t), 'repo');
+  const codexId = randomUUID();
+  const claudeId = randomUUID();
+
+  await hook('session-start', codexId, repo, 'codex');
+  await hook('session-start', claudeId, repo);
+
+  assert.equal(find(codexId).tool, 'codex');
+  assert.equal(find(claudeId).tool, 'claude');
 });


### PR DESCRIPTION
## Summary

Adds first-class Codex Desktop tracking through Codex lifecycle hooks.

The existing shell wrapper tracks the `codex` terminal command, but cannot see sessions started directly in the Codex Desktop app. Users can now enable Desktop tracking with:

```bash
vibe hooks install codex
```

The existing `vibe hooks install` behavior remains unchanged and continues to default to Claude Code Desktop.

## Changes

- Add Codex hook installation through `~/.codex/hooks.json`
- Preserve unrelated hooks and top-level configuration
- Avoid duplicate hooks on repeated installation
- Refresh stale absolute Node and CLI paths on reinstall
- Map `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `Stop`, and `SessionEnd` into the existing hook session engine
- Record sessions with `tool: "codex"`
- Return the required JSON response for Codex `Stop` hooks
- Use the three-second `SessionEnd` timeout supported by Codex
- Add `vibe hooks uninstall codex`
- Document installation, hook review, privacy, and removal

Users review and trust the generated configuration through `/hooks`, then open a fresh Codex Desktop session.

## Privacy

The integration reads only the session ID and working directory from the Codex hook payload. It does not read prompts, transcripts, model responses, or source-file contents.

Git scoring and opt-in leaderboard submission behavior are unchanged.

## Testing

- [x] `npm test` — 17 tests passing
- [x] `npm run build`
- [x] `npm pack --dry-run`
- [x] Non-destructive hook merging
- [x] Idempotent reinstall
- [x] Stale Node and CLI path refresh
- [x] Uninstall preserves unrelated hooks
- [x] Invalid `hooks.json` is not overwritten
- [x] Codex sessions receive the `codex` tool label
- [x] Existing Claude hook sessions still default to `claude`
- [x] Codex `Stop` hook returns valid JSON
- [x] Local build installs all five events without duplication
