### PR TITLE
v0.7 foundation: /config endpoint and JWT refresh

### DIFF
--- a/server/migrations/0003_refresh_tokens.sql
+++ b/server/migrations/0003_refresh_tokens.sql
@@ -1,0 +1,11 @@
+-- Refresh tokens for the v0.7 auth flow: short-lived access JWTs (7d) are
+-- renewed by exchanging a long-lived refresh token. Only the SHA-256 hash of
+-- the token is stored, so a database leak can't mint sessions.
+CREATE TABLE refresh_tokens (
+  token_hash TEXT PRIMARY KEY,
+  user_github_id INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  last_used_at TEXT,
+  revoked_at TEXT
+);
+CREATE INDEX idx_refresh_tokens_user ON refresh_tokens(user_github_id);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,8 @@
 import type { Env } from './env.js';
-import { exchangeAuth } from './routes/auth.js';
+import { exchangeAuth, refreshAuth, revokeAuth } from './routes/auth.js';
 import { submitSession } from './routes/sessions.js';
 import { leaderboardJson, leaderboardHtml } from './routes/leaderboard.js';
+import { clientConfig } from './routes/config.js';
 import { error } from './http.js';
 
 // bump this when a new CLI release should be recommended to clients
@@ -34,6 +35,12 @@ export default {
       switch (route) {
         case 'POST /auth/exchange':
           return withCors(await exchangeAuth(request, env));
+        case 'POST /auth/refresh':
+          return withCors(await refreshAuth(request, env));
+        case 'POST /auth/logout':
+          return withCors(await revokeAuth(request, env));
+        case 'GET /config':
+          return withCors(clientConfig());
         case 'POST /sessions':
           return withCors(await submitSession(request, env));
         case 'GET /leaderboard.json':

--- a/server/src/jwt.ts
+++ b/server/src/jwt.ts
@@ -1,6 +1,6 @@
 const enc = new TextEncoder();
 
-function b64url(bytes: ArrayBuffer | Uint8Array): string {
+export function b64url(bytes: ArrayBuffer | Uint8Array): string {
   const arr = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
   let s = '';
   for (const b of arr) s += String.fromCharCode(b);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,8 +1,24 @@
 import type { Env } from '../env.js';
 import { error, json } from '../http.js';
-import { signJwt } from '../jwt.js';
+import { signJwt, b64url } from '../jwt.js';
 
-const JWT_TTL_SECONDS = 365 * 24 * 60 * 60;
+// Access tokens are short-lived; the CLI renews them via /auth/refresh with a
+// long-lived refresh token, which lets us rotate or revoke without forcing a
+// re-login. Pre-v0.7 CLIs hold 365-day JWTs; those keep verifying until they
+// expire, so this change breaks nobody.
+const JWT_TTL_SECONDS = 7 * 24 * 60 * 60;
+const REFRESH_TTL_MS = 400 * 24 * 60 * 60 * 1000;
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function newRefreshToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return b64url(bytes);
+}
 
 interface GithubUser {
   id: number;
@@ -47,5 +63,58 @@ export async function exchangeAuth(request: Request, env: Env): Promise<Response
 
   const iat = Math.floor(Date.now() / 1000);
   const jwt = await signJwt({ sub: gh.id, handle: gh.login, iat, exp: iat + JWT_TTL_SECONDS }, env.JWT_SECRET);
-  return json({ jwt, handle: gh.login, avatarUrl });
+
+  const refreshToken = newRefreshToken();
+  await env.DB.prepare(
+    `INSERT INTO refresh_tokens (token_hash, user_github_id, created_at) VALUES (?, ?, ?)`,
+  ).bind(await sha256Hex(refreshToken), gh.id, now).run();
+
+  return json({ jwt, refreshToken, handle: gh.login, avatarUrl });
+}
+
+export async function refreshAuth(request: Request, env: Env): Promise<Response> {
+  let body: { refresh_token?: unknown };
+  try {
+    body = (await request.json()) as { refresh_token?: unknown };
+  } catch {
+    return error(400, 'invalid json');
+  }
+  const token = body.refresh_token;
+  if (typeof token !== 'string' || token.length < 32) return error(400, 'refresh_token required');
+
+  const row = await env.DB.prepare(
+    `SELECT rt.user_github_id, rt.created_at, rt.revoked_at, u.handle, u.avatar_url
+     FROM refresh_tokens rt JOIN users u ON u.github_id = rt.user_github_id
+     WHERE rt.token_hash = ?`,
+  ).bind(await sha256Hex(token)).first<{ user_github_id: number; created_at: string; revoked_at: string | null; handle: string; avatar_url: string | null }>();
+
+  if (!row || row.revoked_at !== null) return error(401, 'refresh token invalid');
+  if (Date.now() - Date.parse(row.created_at) > REFRESH_TTL_MS) return error(401, 'refresh token expired');
+
+  await env.DB.prepare(
+    `UPDATE refresh_tokens SET last_used_at = ? WHERE token_hash = ?`,
+  ).bind(new Date().toISOString(), await sha256Hex(token)).run();
+
+  const iat = Math.floor(Date.now() / 1000);
+  const jwt = await signJwt({ sub: row.user_github_id, handle: row.handle, iat, exp: iat + JWT_TTL_SECONDS }, env.JWT_SECRET);
+  return json({ jwt, handle: row.handle, avatarUrl: row.avatar_url });
+}
+
+export async function revokeAuth(request: Request, env: Env): Promise<Response> {
+  let body: { refresh_token?: unknown };
+  try {
+    body = (await request.json()) as { refresh_token?: unknown };
+  } catch {
+    return error(400, 'invalid json');
+  }
+  const token = body.refresh_token;
+  if (typeof token !== 'string' || token.length < 32) return error(400, 'refresh_token required');
+
+  // Idempotent: revoking an unknown or already-revoked token still returns ok,
+  // so logout never fails client-side.
+  await env.DB.prepare(
+    `UPDATE refresh_tokens SET revoked_at = ? WHERE token_hash = ? AND revoked_at IS NULL`,
+  ).bind(new Date().toISOString(), await sha256Hex(token)).run();
+
+  return json({ ok: true });
 }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -8,6 +8,17 @@ import { signJwt, b64url } from '../jwt.js';
 // expire, so this change breaks nobody.
 const JWT_TTL_SECONDS = 7 * 24 * 60 * 60;
 const REFRESH_TTL_MS = 400 * 24 * 60 * 60 * 1000;
+const LEGACY_JWT_TTL_SECONDS = 365 * 24 * 60 * 60;
+
+// Pre-0.7 CLIs can't call /auth/refresh, so a 7-day token would silently log
+// them out a week after every login. They keep getting the long-lived token
+// they were built around; only refresh-capable clients get the short pair.
+function cliSupportsRefresh(request: Request): boolean {
+  const v = request.headers.get('x-cli-version');
+  if (!v) return false;
+  const [major = 0, minor = 0] = v.split('.').map((n) => parseInt(n, 10) || 0);
+  return major > 0 || minor >= 7;
+}
 
 async function sha256Hex(value: string): Promise<string> {
   const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
@@ -62,8 +73,13 @@ export async function exchangeAuth(request: Request, env: Env): Promise<Response
   ).bind(gh.id, gh.login, avatarUrl, now, now).run();
 
   const iat = Math.floor(Date.now() / 1000);
-  const jwt = await signJwt({ sub: gh.id, handle: gh.login, iat, exp: iat + JWT_TTL_SECONDS }, env.JWT_SECRET);
 
+  if (!cliSupportsRefresh(request)) {
+    const jwt = await signJwt({ sub: gh.id, handle: gh.login, iat, exp: iat + LEGACY_JWT_TTL_SECONDS }, env.JWT_SECRET);
+    return json({ jwt, handle: gh.login, avatarUrl });
+  }
+
+  const jwt = await signJwt({ sub: gh.id, handle: gh.login, iat, exp: iat + JWT_TTL_SECONDS }, env.JWT_SECRET);
   const refreshToken = newRefreshToken();
   await env.DB.prepare(
     `INSERT INTO refresh_tokens (token_hash, user_github_id, created_at) VALUES (?, ?, ?)`,

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -1,0 +1,21 @@
+import { json } from '../http.js';
+
+// Client tunables. The CLI ships baked-in copies of these values and treats
+// this endpoint as an override, clamped to sane ranges on the client, so a
+// change here reaches installed CLIs without an npm release. Roughly 30% of
+// installs never update; this endpoint is the only lever we have for them.
+const CLIENT_TUNABLES = {
+  // wrap.ts: how often the wrapper polls git state during a session
+  pollIntervalMs: 30_000,
+  // wrap.ts: how often an in-progress session resubmits to the server
+  inProgressSubmitIntervalMs: 5 * 60_000,
+  // db.ts: idle gap after which session time stops accruing (also the hook
+  // clean-reopen bound and the grace-rescore window)
+  inactivityTimeoutMs: 30 * 60 * 1000,
+};
+
+export function clientConfig(): Response {
+  return json(CLIENT_TUNABLES, {
+    headers: { 'cache-control': 'public, max-age=300' },
+  });
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { chmodSync, existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import open from 'open';
 import { VIBE_DIR, ensureVibeDir } from './config.js';
 import { request, GITHUB_CLIENT_ID, ApiError } from './api.js';
@@ -100,7 +100,12 @@ export function readAuth(): AuthRecord | null {
 
 function writeAuth(record: AuthRecord): void {
   ensureVibeDir();
-  writeFileSync(AUTH_PATH, JSON.stringify(record, null, 2) + '\n');
+  // Write-then-rename: background flushes in the wrapper and hook processes
+  // rewrite this file on renewal, and a torn concurrent write would read as
+  // logged-out forever. Rename makes the swap atomic, like sessions.json.
+  const tmp = `${AUTH_PATH}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(record, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, AUTH_PATH);
   chmodSync(AUTH_PATH, 0o600);
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,9 @@ export interface AuthRecord {
   handle: string;
   avatarUrl: string | null;
   issuedAt: string;
+  // Absent on logins from pre-v0.7 CLIs; those carry a long-lived jwt instead
+  // and fall back to a fresh login when it eventually expires.
+  refreshToken?: string;
 }
 
 export function clearAuth(): void {
@@ -38,8 +41,52 @@ interface PollResponse {
 
 interface ExchangeResponse {
   jwt: string;
+  refreshToken?: string;
   handle: string;
   avatarUrl: string | null;
+}
+
+// Seconds-precision exp claim from the jwt body, without verifying (the server
+// verifies; the client only needs it to know when to renew).
+export function jwtExpiresAtMs(jwt: string): number | null {
+  try {
+    const body = jwt.split('.')[1];
+    const pad = body.length % 4 === 0 ? '' : '='.repeat(4 - (body.length % 4));
+    const payload = JSON.parse(Buffer.from(body.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64').toString('utf-8')) as { exp?: number };
+    return typeof payload.exp === 'number' ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+// Swap the refresh token for a fresh access jwt. Returns the record to use:
+// the renewed one on success, the existing one when the server is unreachable
+// (the old jwt may still be valid), or null when the server rejects the
+// refresh token — auth is dead, and it's cleared so a fresh login can retry.
+export async function refreshAuth(auth: AuthRecord, timeoutMs = 3000): Promise<AuthRecord | null> {
+  if (!auth.refreshToken) return auth;
+  try {
+    const renewed = await request<ExchangeResponse>('/auth/refresh', {
+      method: 'POST',
+      body: { refresh_token: auth.refreshToken },
+      timeoutMs,
+    });
+    const record: AuthRecord = {
+      jwt: renewed.jwt,
+      handle: renewed.handle,
+      avatarUrl: renewed.avatarUrl,
+      issuedAt: new Date().toISOString(),
+      refreshToken: auth.refreshToken,
+    };
+    writeAuth(record);
+    return record;
+  } catch (e) {
+    if (e instanceof ApiError && (e.status === 401 || e.status === 400)) {
+      clearAuth();
+      return null;
+    }
+    return auth;
+  }
 }
 
 export function readAuth(): AuthRecord | null {
@@ -102,6 +149,7 @@ export async function login(): Promise<void> {
     handle: exchanged.handle,
     avatarUrl: exchanged.avatarUrl,
     issuedAt: new Date().toISOString(),
+    refreshToken: exchanged.refreshToken,
   });
   console.log(`  ${PURPLE('◆')} logged in as ${PURPLE('@' + exchanged.handle)}\n`);
 }
@@ -133,10 +181,20 @@ async function pollGithub(device: DeviceCodeResponse): Promise<string | null> {
   return null;
 }
 
-export function logout(): void {
+export async function logout(): Promise<void> {
   if (!existsSync(AUTH_PATH)) {
     console.log(`\n  ${PURPLE('◆')} not logged in\n`);
     return;
+  }
+  // Best-effort server-side revocation so the refresh token can't be reused;
+  // local logout succeeds regardless.
+  const auth = readAuth();
+  if (auth?.refreshToken) {
+    await request('/auth/logout', {
+      method: 'POST',
+      body: { refresh_token: auth.refreshToken },
+      timeoutMs: 3000,
+    }).catch(() => {});
   }
   unlinkSync(AUTH_PATH);
   console.log(`\n  ${PURPLE('◆')} logged out\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -176,8 +176,8 @@ program
 program
   .command('logout')
   .description('sign out of the leaderboard')
-  .action(() => {
-    logout();
+  .action(async () => {
+    await logout();
   });
 
 program

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { readFileSync, writeFileSync, renameSync, mkdirSync, rmdirSync, unlinkSync, statSync, existsSync } from 'node:fs';
 import { VIBE_DIR, ensureVibeDir } from './config.js';
+import { TUNABLES } from './remote-config.js';
 import type { MomentumTier } from './score.js';
 import type { RepoBaseline } from './git.js';
 
@@ -43,7 +44,10 @@ interface DbSchema {
   sessions: Session[];
 }
 
-export const INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+// Server-tunable via /config (clamped, cached in ~/.vibe/remote-config.json);
+// 30 minutes unless the server says otherwise. Re-exported here because every
+// consumer of the timeout historically imports it from db.
+export const INACTIVITY_TIMEOUT_MS = TUNABLES.inactivityTimeoutMs;
 
 const DB_PATH = join(VIBE_DIR, 'sessions.json');
 const TMP_PATH = DB_PATH + '.tmp';

--- a/src/remote-config.ts
+++ b/src/remote-config.ts
@@ -1,0 +1,81 @@
+import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { VIBE_DIR, ensureVibeDir } from './config.js';
+import { request } from './api.js';
+
+export interface Tunables {
+  pollIntervalMs: number;
+  inProgressSubmitIntervalMs: number;
+  inactivityTimeoutMs: number;
+}
+
+// Baked-in values, used whenever the server has never been reached. These must
+// stay safe to run forever: an installed CLI that never updates and never gets
+// a config fetch through still behaves exactly like v0.6.
+const DEFAULTS: Tunables = {
+  pollIntervalMs: 30_000,
+  inProgressSubmitIntervalMs: 5 * 60_000,
+  inactivityTimeoutMs: 30 * 60 * 1000,
+};
+
+// Server values are clamped so a bad deploy (or a compromised response) can't
+// brick installed clients: no 1ms poll loops, no 1-second idle timeouts that
+// zero every session.
+const CLAMPS: Record<keyof Tunables, [number, number]> = {
+  pollIntervalMs: [5_000, 5 * 60_000],
+  inProgressSubmitIntervalMs: [60_000, 60 * 60_000],
+  inactivityTimeoutMs: [5 * 60_000, 4 * 60 * 60 * 1000],
+};
+
+const CACHE_PATH = join(VIBE_DIR, 'remote-config.json');
+const STALE_AFTER_MS = 6 * 60 * 60 * 1000;
+
+function clamp(key: keyof Tunables, value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULTS[key];
+  const [lo, hi] = CLAMPS[key];
+  return Math.min(Math.max(Math.round(value), lo), hi);
+}
+
+// Read once at module load: every consumer (wrapper poller, hook engine,
+// reaper, grace rescore) sees the same values for the life of the process.
+// Hook processes must never fetch — codex gives session-end hooks 3 seconds —
+// so this is a local file read only; refreshTunables() below does the network.
+function load(): Tunables & { fetchedAt?: string } {
+  if (!existsSync(CACHE_PATH)) return { ...DEFAULTS };
+  try {
+    const raw = JSON.parse(readFileSync(CACHE_PATH, 'utf-8')) as Partial<Tunables> & { fetchedAt?: string };
+    return {
+      pollIntervalMs: clamp('pollIntervalMs', raw.pollIntervalMs),
+      inProgressSubmitIntervalMs: clamp('inProgressSubmitIntervalMs', raw.inProgressSubmitIntervalMs),
+      inactivityTimeoutMs: clamp('inactivityTimeoutMs', raw.inactivityTimeoutMs),
+      fetchedAt: raw.fetchedAt,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+const loaded = load();
+
+export const TUNABLES: Tunables = {
+  pollIntervalMs: loaded.pollIntervalMs,
+  inProgressSubmitIntervalMs: loaded.inProgressSubmitIntervalMs,
+  inactivityTimeoutMs: loaded.inactivityTimeoutMs,
+};
+
+// Fire-and-forget refresh for contexts that can afford network (the wrapper at
+// session start). Skips when the cache is fresh; failures leave the cache as
+// is. New values apply to the NEXT process, never mid-session.
+export async function refreshTunables(): Promise<void> {
+  if (loaded.fetchedAt && Date.now() - Date.parse(loaded.fetchedAt) < STALE_AFTER_MS) return;
+  try {
+    const fetched = await request<Partial<Tunables>>('/config', { timeoutMs: 3000 });
+    ensureVibeDir();
+    writeFileSync(CACHE_PATH, JSON.stringify({
+      pollIntervalMs: clamp('pollIntervalMs', fetched.pollIntervalMs),
+      inProgressSubmitIntervalMs: clamp('inProgressSubmitIntervalMs', fetched.inProgressSubmitIntervalMs),
+      inactivityTimeoutMs: clamp('inactivityTimeoutMs', fetched.inactivityTimeoutMs),
+      fetchedAt: new Date().toISOString(),
+    }, null, 2) + '\n');
+  } catch {}
+}

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -1,7 +1,11 @@
 import { createHash } from 'node:crypto';
 import { getSessions, updateSession, type Session } from './db.js';
-import { readAuth, clearAuth } from './auth.js';
+import { readAuth, clearAuth, refreshAuth, jwtExpiresAtMs, type AuthRecord } from './auth.js';
 import { request, ApiError } from './api.js';
+
+// Renew ahead of expiry so submissions rarely meet a 401. Two days of slack on
+// a seven-day token means one successful flush a week keeps auth alive forever.
+const RENEW_BEFORE_MS = 48 * 60 * 60 * 1000;
 
 function projectHash(project: string): string {
   return createHash('sha256').update(project).digest('hex').slice(0, 16);
@@ -35,20 +39,33 @@ export async function submitInProgress(session: Session, budgetMs = 1500): Promi
       timeoutMs: budgetMs,
     });
   } catch (e) {
-    if (e instanceof ApiError && e.status === 401) clearAuth();
+    // A stale access token gets renewed by the next flush; only a legacy
+    // record with no refresh token is dropped here, so a fresh login retries.
+    if (e instanceof ApiError && e.status === 401 && !auth.refreshToken) clearAuth();
   }
 }
 
 export async function flushPendingSubmissions(budgetMs: number): Promise<void> {
-  const auth = readAuth();
+  let auth: AuthRecord | null = readAuth();
   if (!auth) return;
 
   const deadline = Date.now() + budgetMs;
+
+  // Proactive renewal when the access token is close to expiry. A failed
+  // renewal falls through with the current jwt, which may still be valid.
+  const exp = jwtExpiresAtMs(auth.jwt);
+  if (auth.refreshToken && exp !== null && exp - Date.now() < RENEW_BEFORE_MS) {
+    auth = await refreshAuth(auth, Math.min(budgetMs, 3000));
+    if (!auth) return; // refresh rejected: local auth already cleared
+  }
+
   const pending = getSessions()
     .filter((s) => !s.submittedAt && s.exitCode !== -1 && s.durationSeconds >= 60)
     .sort((a, b) => a.startedAt.localeCompare(b.startedAt));
 
-  for (const session of pending) {
+  let renewedOnce = false;
+  for (let i = 0; i < pending.length; i++) {
+    const session = pending[i];
     const remaining = deadline - Date.now();
     if (remaining <= 0) return;
     const perRequest = Math.min(remaining, 1500);
@@ -63,7 +80,19 @@ export async function flushPendingSubmissions(budgetMs: number): Promise<void> {
     } catch (e) {
       if (e instanceof ApiError) {
         if (e.status === 401) {
-          // auth is bad: drop the token, leave sessions unsubmitted so a fresh login retries them
+          if (auth.refreshToken && !renewedOnce) {
+            renewedOnce = true;
+            const renewed = await refreshAuth(auth, Math.min(deadline - Date.now(), 3000));
+            if (!renewed) return; // refresh rejected: local auth already cleared
+            if (renewed.jwt !== auth.jwt) {
+              auth = renewed;
+              i--; // retry this session with the fresh token
+              continue;
+            }
+            return; // couldn't reach the server to renew: retry next flush
+          }
+          // no refresh token (pre-v0.7 login) or still 401 after renewing:
+          // drop the token, leave sessions unsubmitted so a fresh login retries them
           clearAuth();
           return;
         }

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -8,10 +8,11 @@ import { scoreSession } from './score.js';
 import { renderEndcard } from './render.js';
 import { flushPendingSubmissions, submitInProgress } from './submit.js';
 import { getRecommendedVersion } from './api.js';
+import { TUNABLES, refreshTunables } from './remote-config.js';
 import { PURPLE } from './colors.js';
 
-const POLL_INTERVAL_MS = 30_000;
-const IN_PROGRESS_SUBMIT_INTERVAL_MS = 5 * 60_000;
+const POLL_INTERVAL_MS = TUNABLES.pollIntervalMs;
+const IN_PROGRESS_SUBMIT_INTERVAL_MS = TUNABLES.inProgressSubmitIntervalMs;
 
 function reportSpawnError(tool: string, err: NodeJS.ErrnoException): void {
   if (err.code === 'ENOENT') {
@@ -47,6 +48,10 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
   let lastActivityAt = startedAt;
   let totalGapMs = 0;
   let idleSince = 0;
+
+  // Refresh the server tunables in the background; whatever it fetches applies
+  // to the next session, never this one mid-flight.
+  refreshTunables().catch(() => {});
 
   await refreshAndReap();
 

--- a/test/auth-refresh.test.mjs
+++ b/test/auth-refresh.test.mjs
@@ -1,0 +1,141 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+// VIBE_DIR and VIBE_API are read at module load, so scratch dir and stub
+// server come up before the first dist import.
+const scratch = mkdtempSync(join(tmpdir(), 'vibe-auth-refresh-'));
+process.env.VIBE_DIR = scratch;
+delete process.env.VIBE_SESSION;
+
+// Scriptable stub API: each test sets handlers per path; a handler is called
+// with the parsed body and returns [status, responseBody].
+const handlers = {};
+const calls = [];
+const server = createServer((req, res) => {
+  let raw = '';
+  req.on('data', (c) => { raw += c; });
+  req.on('end', () => {
+    calls.push(req.url);
+    const handler = handlers[req.url];
+    if (!handler) {
+      res.statusCode = 404;
+      return res.end('{"error":"no handler"}');
+    }
+    const [status, body] = handler(raw ? JSON.parse(raw) : null);
+    res.statusCode = status;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify(body));
+  });
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+process.env.VIBE_API = `http://127.0.0.1:${server.address().port}`;
+after(() => server.close());
+
+const { refreshAuth, jwtExpiresAtMs, readAuth, AUTH_PATH } = await import('../dist/auth.js');
+const { addSession, getSessions } = await import('../dist/db.js');
+const { flushPendingSubmissions } = await import('../dist/submit.js');
+
+function fakeJwt(expSecondsFromNow) {
+  const b64u = (s) => Buffer.from(s).toString('base64url');
+  const payload = { sub: 1, handle: 't', exp: Math.floor(Date.now() / 1000) + expSecondsFromNow };
+  return `${b64u('{"alg":"HS256","typ":"JWT"}')}.${b64u(JSON.stringify(payload))}.stub`;
+}
+
+function writeAuthFile(record) {
+  writeFileSync(AUTH_PATH, JSON.stringify(record, null, 2) + '\n');
+}
+
+function baseAuth(overrides = {}) {
+  return {
+    jwt: fakeJwt(100 * 24 * 3600),
+    handle: 't',
+    avatarUrl: null,
+    issuedAt: new Date().toISOString(),
+    refreshToken: 'r'.repeat(43),
+    ...overrides,
+  };
+}
+
+test('jwtExpiresAtMs reads exp and rejects garbage', () => {
+  const soon = jwtExpiresAtMs(fakeJwt(3600));
+  assert.ok(Math.abs(soon - (Date.now() + 3600_000)) < 5000);
+  assert.equal(jwtExpiresAtMs('not-a-jwt'), null);
+});
+
+test('refreshAuth swaps the jwt and keeps the refresh token', async () => {
+  const auth = baseAuth();
+  writeAuthFile(auth);
+  const newJwt = fakeJwt(7 * 24 * 3600);
+  handlers['/auth/refresh'] = (body) => {
+    assert.equal(body.refresh_token, auth.refreshToken);
+    return [200, { jwt: newJwt, handle: 't', avatarUrl: null }];
+  };
+
+  const renewed = await refreshAuth(auth);
+  assert.equal(renewed.jwt, newJwt);
+  assert.equal(renewed.refreshToken, auth.refreshToken);
+  assert.equal(readAuth().jwt, newJwt);
+});
+
+test('a rejected refresh clears local auth', async () => {
+  const auth = baseAuth();
+  writeAuthFile(auth);
+  handlers['/auth/refresh'] = () => [401, { error: 'refresh token invalid' }];
+
+  const renewed = await refreshAuth(auth);
+  assert.equal(renewed, null);
+  assert.equal(existsSync(AUTH_PATH), false);
+});
+
+test('a legacy record without a refresh token never touches the network', async () => {
+  const auth = baseAuth({ refreshToken: undefined });
+  const before = calls.length;
+  const renewed = await refreshAuth(auth);
+  assert.equal(renewed, auth);
+  assert.equal(calls.length, before);
+});
+
+test('flush renews once on 401 and retries the submission', async () => {
+  rmSync(join(scratch, 'sessions.json'), { force: true });
+  const auth = baseAuth();
+  writeAuthFile(auth);
+  const newJwt = fakeJwt(7 * 24 * 3600);
+
+  const id = randomUUID();
+  await addSession({
+    id, tool: 'claude', project: 'repo', branch: 'main',
+    startedAt: new Date(Date.now() - 600_000).toISOString(),
+    endedAt: new Date().toISOString(),
+    durationSeconds: 300, commits: 1, linesAdded: 10, linesRemoved: 2, filesTouched: 1,
+    momentum: 'shipped', exitCode: 0, lastActivityAt: new Date().toISOString(),
+  });
+
+  let sessionCalls = 0;
+  handlers['/sessions'] = () => {
+    sessionCalls++;
+    return sessionCalls === 1 ? [401, { error: 'token expired' }] : [200, { ok: true, submittedAt: new Date().toISOString() }];
+  };
+  handlers['/auth/refresh'] = () => [200, { jwt: newJwt, handle: 't', avatarUrl: null }];
+
+  await flushPendingSubmissions(10_000);
+
+  assert.equal(sessionCalls, 2);
+  assert.equal(readAuth().jwt, newJwt);
+  assert.ok(getSessions().find((s) => s.id === id).submittedAt);
+});
+
+test('flush renews proactively when the jwt is close to expiry', async () => {
+  rmSync(join(scratch, 'sessions.json'), { force: true });
+  const auth = baseAuth({ jwt: fakeJwt(3600) }); // expires within the 48h window
+  writeAuthFile(auth);
+  const newJwt = fakeJwt(7 * 24 * 3600);
+  handlers['/auth/refresh'] = () => [200, { jwt: newJwt, handle: 't', avatarUrl: null }];
+
+  await flushPendingSubmissions(10_000);
+  assert.equal(readAuth().jwt, newJwt);
+});

--- a/test/remote-config.test.mjs
+++ b/test/remote-config.test.mjs
@@ -1,0 +1,80 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer } from 'node:http';
+
+// Both VIBE_DIR and VIBE_API are read at module load time in dist, so the
+// scratch dir and the stub server must exist before the first dist import.
+// Tests that need a different cache state re-import remote-config with a
+// cache-busting query so its load() runs again (api.js stays loaded, which is
+// fine: API_BASE points at the stub for the whole file).
+const scratch = mkdtempSync(join(tmpdir(), 'vibe-remote-config-'));
+process.env.VIBE_DIR = scratch;
+delete process.env.VIBE_SESSION;
+
+let hits = 0;
+const server = createServer((req, res) => {
+  hits++;
+  assert.equal(req.url, '/config');
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ pollIntervalMs: 45_000, inProgressSubmitIntervalMs: 999, inactivityTimeoutMs: 3_600_000 }));
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+process.env.VIBE_API = `http://127.0.0.1:${server.address().port}`;
+after(() => server.close());
+
+const CACHE = join(scratch, 'remote-config.json');
+let importSeq = 0;
+async function freshModule() {
+  return import(`../dist/remote-config.js?seq=${importSeq++}`);
+}
+
+test('defaults apply when no cache exists', async () => {
+  const { TUNABLES } = await freshModule();
+  assert.equal(TUNABLES.pollIntervalMs, 30_000);
+  assert.equal(TUNABLES.inProgressSubmitIntervalMs, 300_000);
+  assert.equal(TUNABLES.inactivityTimeoutMs, 1_800_000);
+});
+
+test('cached values are used, absurd ones are clamped', async () => {
+  writeFileSync(CACHE, JSON.stringify({
+    pollIntervalMs: 60_000,          // valid, kept
+    inProgressSubmitIntervalMs: 1,   // absurd, clamped up
+    inactivityTimeoutMs: 1e12,       // absurd, clamped down
+    fetchedAt: new Date().toISOString(),
+  }));
+  const { TUNABLES } = await freshModule();
+  assert.equal(TUNABLES.pollIntervalMs, 60_000);
+  assert.equal(TUNABLES.inProgressSubmitIntervalMs, 60_000);
+  assert.equal(TUNABLES.inactivityTimeoutMs, 4 * 60 * 60 * 1000);
+});
+
+test('corrupt cache falls back to defaults', async () => {
+  writeFileSync(CACHE, 'not json at all\n');
+  const { TUNABLES } = await freshModule();
+  assert.equal(TUNABLES.pollIntervalMs, 30_000);
+  assert.equal(TUNABLES.inactivityTimeoutMs, 1_800_000);
+});
+
+test('refreshTunables fetches, clamps, and writes the cache', async () => {
+  writeFileSync(CACHE, JSON.stringify({ fetchedAt: '2020-01-01T00:00:00Z' })); // stale
+  const { refreshTunables } = await freshModule();
+  await refreshTunables();
+
+  const cached = JSON.parse(readFileSync(CACHE, 'utf-8'));
+  assert.equal(cached.pollIntervalMs, 45_000);
+  assert.equal(cached.inProgressSubmitIntervalMs, 60_000); // clamped
+  assert.equal(cached.inactivityTimeoutMs, 3_600_000);
+  assert.ok(cached.fetchedAt > '2025');
+});
+
+test('a fresh cache skips the network entirely', async () => {
+  writeFileSync(CACHE, JSON.stringify({ pollIntervalMs: 45_000, fetchedAt: new Date().toISOString() }));
+  const before = hits;
+  const { refreshTunables } = await freshModule();
+  await refreshTunables();
+  assert.equal(hits, before);
+  assert.equal(JSON.parse(readFileSync(CACHE, 'utf-8')).pollIntervalMs, 45_000);
+});


### PR DESCRIPTION
The two foundation items queued for v0.7.

## /config endpoint

`GET /config` serves the client tunables: poll interval, in-progress submit interval, inactivity timeout. The CLI caches the response in `~/.vibe/remote-config.json` and reads it at startup, so production timing can be changed with a server deploy instead of an npm release (roughly 30% of installs never update, this is the only lever for them).

- Every value is clamped client-side to a sane range, so a bad deploy or compromised response can't brick installed CLIs (no 1ms poll loops, no 1-second idle timeouts).
- Baked-in defaults match v0.6 exactly. A CLI that never reaches the server behaves identically to today.
- The wrapper refreshes the cache in the background at session start (skipped when fresh, under 6h old). Hook processes only ever read the cache, never fetch: codex gives session-end hooks 3 seconds.
- New values apply to the next process, never mid-session.

## JWT refresh

Access tokens drop from 365 days to 7, renewed via a long-lived refresh token (400 days, stored as a SHA-256 hash server-side, migration 0003).

- `POST /auth/refresh` swaps the refresh token for a fresh access JWT.
- `POST /auth/logout` revokes the refresh token; `vibe logout` calls it best-effort before clearing local auth.
- The submission flush renews proactively when the JWT is within 48h of expiry, and retries once after a 401.
- Backward compatible: pre-v0.7 logins keep their 365-day JWTs until expiry and the old 401-clears-auth behavior. New logins get the token pair.

## Testing

- 34/34 tests (11 new: tunables clamping/fallback/staleness, refresh success/rejection/legacy, flush 401-retry and proactive renewal against a stub API).
- Server typechecked; migration applies cleanly to local D1.
- Live e2e against wrangler dev: /config serves tunables; seeded refresh token -> real 7-day JWT (exp - iat = 604800); revoke -> ok; refresh after revoke -> 401.
- Wrapped-session smoke: the tunables cache is written by the wrap path.

## Deploy order for the release

Reversed from usual: the server must deploy first this time (with `wrangler d1 migrations apply vibetime`), because the new CLI calls /config and /auth/refresh. Then npm publish, then the recommended-version bump and redeploy.
