### PR TITLE
replace claude code hooks that codex imported on reinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ vibe hooks install
 Either way it registers session hooks in `~/.claude/settings.json` and `~/.codex/hooks.json` for both apps, including one you haven't installed yet: hooks are inert config until the app exists, so if you switch apps months from now you're already tracked without re-running anything. Hooks Vibetime didn't create are never touched. From then on, every Desktop session is recorded and shows up in `vibe status`, `vibe log`, `vibe share`, and the leaderboard, exactly like a terminal session.
 
 - **Claude Code** hot-reloads its settings: just open a new Desktop session.
-- **Codex** asks you to trust new hooks once: run `/hooks` in Codex, review the commands, then open a new session. Needs a Codex build from May 2026 or later (when hooks became generally available). Tested on macOS and Linux. Windows is untested: the hooks include a Windows command variant, reports welcome.
+- **Codex** asks you to trust new hooks once: run `/hooks` in Codex, review the commands, then open a new session. Needs a Codex build from May 2026 or later (when hooks became generally available). Tested on macOS and Linux. Windows is untested: the hooks include a Windows command variant, reports welcome. If Codex imported your Claude Code hooks, `vibe hooks install` replaces those copies with the Codex versions, which tag sessions as Codex and fit its 3-second SessionEnd limit.
 
 Duration is measured the same way as the terminal: active coding time, with idle gaps over 30 minutes excluded.
 

--- a/src/claude-hooks.ts
+++ b/src/claude-hooks.ts
@@ -51,11 +51,14 @@ function vibeCommand(event: HookEvent): string {
   return `${shellQuote(process.execPath)} ${shellQuote(cli)} __hook ${event}`;
 }
 
-function isVibeHook(group: HookGroup): boolean {
+export function isVibeHook(group: HookGroup): boolean {
   // `__hook` is our coined subcommand — matching it alone is enough. Don't also
   // require the literal "vibe" in the path: a dev clone in a differently named
   // directory has no "vibe" in its cli.js path, which would make reinstall
-  // duplicate our hooks and uninstall miss them.
+  // duplicate our hooks and uninstall miss them. Don't require `--tool codex`
+  // on the Codex side either: Codex can import these Claude Code entries into
+  // its own hooks.json verbatim, and the Codex installer has to claim those
+  // copies so it can replace them rather than run alongside them.
   return Array.isArray(group?.hooks) && group.hooks.some(
     (h) => typeof h?.command === 'string' && h.command.includes('__hook'),
   );

--- a/src/codex-hooks.ts
+++ b/src/codex-hooks.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { PURPLE } from './colors.js';
+import { isVibeHook } from './claude-hooks.js';
 
 const RED = chalk.hex('#EF4444');
 
@@ -64,14 +65,6 @@ export function codexHookCommandWindows(event: HookEvent, hookEventName: string)
   return hookInvocation(event, hookEventName, winQuote);
 }
 
-function isCodexVibeHook(group: HookGroup): boolean {
-  return Array.isArray(group?.hooks) && group.hooks.some(
-    (hook) => typeof hook?.command === 'string'
-      && hook.command.includes('__hook')
-      && hook.command.includes('--tool codex'),
-  );
-}
-
 export function mergeCodexHooks(config: CodexHooksConfig): {
   config: CodexHooksConfig;
   added: number;
@@ -97,11 +90,11 @@ export function mergeCodexHooks(config: CodexHooksConfig): {
     };
     if (codexEvent === 'PostToolUse') group.matcher = '';
 
-    const ours = list.filter(isCodexVibeHook);
+    const ours = list.filter(isVibeHook);
     if (ours.length > 0) {
       existing++;
       if (ours.length !== 1 || JSON.stringify(ours[0]) !== JSON.stringify(group)) updated++;
-      hooks[codexEvent] = [...list.filter((candidate) => !isCodexVibeHook(candidate)), group];
+      hooks[codexEvent] = [...list.filter((candidate) => !isVibeHook(candidate)), group];
     } else {
       list.push(group);
       hooks[codexEvent] = list;
@@ -121,7 +114,7 @@ export function stripCodexHooks(config: CodexHooksConfig): { config: CodexHooksC
     const list = config.hooks[event];
     if (!Array.isArray(list)) continue;
     const kept = list.filter((group) => {
-      const ours = isCodexVibeHook(group);
+      const ours = isVibeHook(group);
       if (ours) removed++;
       return !ours;
     });

--- a/test/codex-hooks.test.mjs
+++ b/test/codex-hooks.test.mjs
@@ -76,6 +76,46 @@ test('reinstall refreshes stale commands without duplicating hooks', () => {
   assert.doesNotMatch(vibeGroups[0].hooks[0].command, /old\/node/);
 });
 
+// What Codex writes to hooks.json when it imports ~/.claude/settings.json: the
+// Claude Code entries verbatim, so no --tool codex and a SessionEnd timeout
+// above the 3s Codex allows.
+function importedClaudeHook(event) {
+  return { hooks: [{ type: 'command', command: `'/usr/bin/node' '/lib/vibetime-cli/dist/cli.js' __hook ${event}`, timeout: 10 }] };
+}
+
+test('reinstall replaces Claude Code hooks that Codex imported', () => {
+  const unrelated = otherHook();
+  const config = {
+    hooks: {
+      SessionStart: [importedClaudeHook('session-start')],
+      UserPromptSubmit: [importedClaudeHook('activity')],
+      PostToolUse: [{ matcher: '', ...importedClaudeHook('activity') }],
+      Stop: [importedClaudeHook('activity'), unrelated],
+      SessionEnd: [importedClaudeHook('session-end')],
+    },
+  };
+
+  const { config: merged, added, existing, updated } = mergeCodexHooks(config);
+  assert.equal(added, 0);
+  assert.equal(existing, 5);
+  assert.equal(updated, 5);
+  for (const event of ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'Stop', 'SessionEnd']) {
+    const vibeGroups = merged.hooks[event].filter((group) => group.hooks.some((hook) => hook.command.includes('__hook')));
+    assert.equal(vibeGroups.length, 1, event);
+    assert.match(vibeGroups[0].hooks[0].command, /--tool codex/, event);
+  }
+  assert.equal(merged.hooks.SessionEnd[0].hooks[0].timeout, 3);
+  assert.equal(merged.hooks.Stop[0], unrelated);
+});
+
+test('uninstall removes Claude Code hooks that Codex imported', () => {
+  const { config, removed } = stripCodexHooks({
+    hooks: { SessionEnd: [importedClaudeHook('session-end'), otherHook()] },
+  });
+  assert.equal(removed, 1);
+  assert.deepEqual(config.hooks, { SessionEnd: [otherHook()] });
+});
+
 test('Codex hook removal preserves unrelated hooks and top-level settings', () => {
   const config = mergeCodexHooks({
     description: 'keep me',


### PR DESCRIPTION
Codex can import the hooks from `~/.claude/settings.json` into `~/.codex/hooks.json` as-is. When that happens the vibetime entries have no `--tool codex` flag, so Codex sessions get logged as Claude Code, and SessionEnd keeps the 10s timeout that Codex clamps to 3s with a warning in `/hooks`.

The Codex installer only recognised entries carrying `--tool codex`, so `vibe hooks install` would add a second set of hooks beside the copies and `vibe hooks uninstall` would leave them behind. Both installers now match on the `__hook` subcommand and share the one matcher from claude-hooks.

Checked against a copy of a real imported hooks.json: the five copies are replaced with the Codex entries and every other hook in the file is untouched. Two new tests cover reinstall and uninstall over imported entries.
