### PR TITLE
Per-day ship events

### DIFF
--- a/server/migrations/0004_ship_events.sql
+++ b/server/migrations/0004_ship_events.sql
@@ -1,0 +1,15 @@
+-- Per-day ship events: a session that ships across several days counts once
+-- per day it shipped, not once on its end day. Backfilled from existing
+-- shipped sessions as a single end-day event, which matches the old counting
+-- exactly, so history is continuous.
+CREATE TABLE ship_events (
+  session_id TEXT NOT NULL,
+  user_github_id INTEGER NOT NULL,
+  day TEXT NOT NULL,
+  PRIMARY KEY (session_id, day)
+);
+CREATE INDEX idx_ship_events_user_day ON ship_events(user_github_id, day);
+CREATE INDEX idx_ship_events_day ON ship_events(day);
+
+INSERT INTO ship_events (session_id, user_github_id, day)
+  SELECT id, user_github_id, date(ended_at) FROM sessions WHERE momentum = 'shipped';

--- a/server/src/routes/leaderboard.ts
+++ b/server/src/routes/leaderboard.ts
@@ -68,39 +68,45 @@ async function buildData(env: Env, window: Window): Promise<LeaderboardData> {
     : window === 'month' ? startOfCalendarMonth().getTime()
     : window === 'week' ? startOfCalendarWeek().getTime()
     : Date.now() - WINDOWS[window];
-  const sinceIso = new Date(sinceMs).toISOString();
+  // Ship events are keyed by UTC day; the calendar windows start at UTC
+  // midnight, so a plain day-string comparison matches them exactly.
+  const sinceDay = new Date(sinceMs).toISOString().slice(0, 10);
 
   const totalsRes = await env.DB.prepare(
     `SELECT COUNT(DISTINCT user_github_id) AS dev_count, COUNT(*) AS session_count
-     FROM sessions
-     WHERE momentum = 'shipped' AND ended_at > ?`,
-  ).bind(sinceIso).first<{ dev_count: number; session_count: number }>();
+     FROM ship_events
+     WHERE day >= ?`,
+  ).bind(sinceDay).first<{ dev_count: number; session_count: number }>();
   const devCount = totalsRes?.dev_count ?? 0;
   const sessionCount = totalsRes?.session_count ?? 0;
 
+  // Rank by ship events; timestamps for "last shipped" and the join-order
+  // tiebreak still come from the underlying sessions.
   const topRes = await env.DB.prepare(
     `SELECT u.github_id, u.handle, u.avatar_url,
             COUNT(*) AS shipped_count,
             MAX(s.ended_at) AS last_shipped_at,
             MIN(s.started_at) AS first_at
-     FROM sessions s JOIN users u ON s.user_github_id = u.github_id
-     WHERE s.momentum = 'shipped' AND s.ended_at > ?
+     FROM ship_events e
+     JOIN sessions s ON s.id = e.session_id
+     JOIN users u ON e.user_github_id = u.github_id
+     WHERE e.day >= ?
      GROUP BY u.github_id
      ORDER BY shipped_count DESC, first_at ASC
      LIMIT 100`,
-  ).bind(sinceIso).all<LeaderboardRow>();
+  ).bind(sinceDay).all<LeaderboardRow>();
 
   const rows = topRes.results ?? [];
   if (rows.length === 0) return { entries: [], devCount, sessionCount };
 
-  const heatmapSince = new Date(Date.now() - HEATMAP_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const heatmapSinceDay = new Date(Date.now() - HEATMAP_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const placeholders = rows.map(() => '?').join(',');
   const dailyRes = await env.DB.prepare(
-    `SELECT user_github_id, date(ended_at) AS day, COUNT(*) AS n
-     FROM sessions
-     WHERE momentum = 'shipped' AND ended_at > ? AND user_github_id IN (${placeholders})
+    `SELECT user_github_id, day, COUNT(*) AS n
+     FROM ship_events
+     WHERE day >= ? AND user_github_id IN (${placeholders})
      GROUP BY user_github_id, day`,
-  ).bind(heatmapSince, ...rows.map((r) => r.github_id)).all<DailyCount>();
+  ).bind(heatmapSinceDay, ...rows.map((r) => r.github_id)).all<DailyCount>();
 
   const dailyByUser = new Map<number, Map<string, number>>();
   for (const d of dailyRes.results ?? []) {

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -52,6 +52,9 @@ function parseSession(raw: unknown): IncomingSession | string {
     for (const day of s.shipEvents) {
       if (typeof day !== 'string' || !DAY_RE.test(day) || isNaN(Date.parse(day))) return 'invalid shipEvents';
     }
+    // Every event needs at least one new commit in its delta, so a session can
+    // never honestly claim more event days than it has commits.
+    if (s.shipEvents.length > (s.commits as number)) return 'shipEvents exceed commits';
   }
   return s as unknown as IncomingSession;
 }

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -9,8 +9,13 @@ const VALID_TIERS = new Set(['shipped', 'progressed', 'tinkering', 'exploring', 
 const VALID_TOOLS_RE = /^[a-z][a-z0-9_-]{0,31}$/i;
 const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 const MIN_DURATION_S = 60;
+// Anti-gaming: at most this many ship events per user per UTC day. Enforced by
+// silently dropping excess event rows — the session itself still stores, so
+// clients (including pre-0.8 ones that used to see a 429 here) never retry.
 const DAILY_SHIPPED_CAP = 10;
-const SHIPPED_WINDOW_MS = 24 * 60 * 60 * 1000;
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_SHIP_EVENTS = 62;
+const DAY_SLACK_MS = 24 * 60 * 60 * 1000;
 
 interface IncomingSession {
   id: string;
@@ -24,6 +29,7 @@ interface IncomingSession {
   linesRemoved: number;
   filesTouched: number;
   momentum?: string;
+  shipEvents?: string[];
 }
 
 function parseSession(raw: unknown): IncomingSession | string {
@@ -41,6 +47,12 @@ function parseSession(raw: unknown): IncomingSession | string {
   if (typeof s.filesTouched !== 'number' || s.filesTouched < 0) return 'invalid filesTouched';
   // momentum is now optional — server is authoritative — but validate the shape if old clients still send it
   if (s.momentum !== undefined && (typeof s.momentum !== 'string' || !VALID_TIERS.has(s.momentum))) return 'invalid momentum';
+  if (s.shipEvents !== undefined) {
+    if (!Array.isArray(s.shipEvents) || s.shipEvents.length > MAX_SHIP_EVENTS) return 'invalid shipEvents';
+    for (const day of s.shipEvents) {
+      if (typeof day !== 'string' || !DAY_RE.test(day) || isNaN(Date.parse(day))) return 'invalid shipEvents';
+    }
+  }
   return s as unknown as IncomingSession;
 }
 
@@ -56,6 +68,16 @@ export async function submitSession(request: Request, env: Env): Promise<Respons
   const startedAtMs = Date.parse(parsed.startedAt);
   if (Date.now() - startedAtMs > MAX_AGE_MS) return error(400, 'session too old');
   if (parsed.durationSeconds < MIN_DURATION_S) return error(400, 'session too short');
+
+  // Event days must fall within the session's lifespan (a day of slack each
+  // side for clock skew) — no forging history outside the session.
+  if (parsed.shipEvents) {
+    const endedAtMs = Date.parse(parsed.endedAt);
+    for (const day of parsed.shipEvents) {
+      const dayMs = Date.parse(day);
+      if (dayMs < startedAtMs - DAY_SLACK_MS * 2 || dayMs > endedAtMs + DAY_SLACK_MS) return error(400, 'shipEvents outside session');
+    }
+  }
 
   // confirm the user row still exists (defends against FK insert failure if the row was deleted)
   // v1.1 follow-up: verify commit history against the user's public GitHub events
@@ -73,14 +95,6 @@ export async function submitSession(request: Request, env: Env): Promise<Respons
     linesRemoved: parsed.linesRemoved,
     filesTouched: parsed.filesTouched,
   });
-
-  if (momentum === 'shipped') {
-    const since = new Date(Date.now() - SHIPPED_WINDOW_MS).toISOString();
-    const existing = await env.DB.prepare(
-      `SELECT COUNT(*) AS n FROM sessions WHERE user_github_id = ? AND momentum = 'shipped' AND started_at >= ? AND id != ?`,
-    ).bind(auth.sub, since, parsed.id).first<{ n: number }>();
-    if ((existing?.n ?? 0) >= DAILY_SHIPPED_CAP) return error(429, 'daily shipped cap reached');
-  }
 
   const submittedAt = new Date().toISOString();
   await env.DB.prepare(
@@ -105,6 +119,32 @@ export async function submitSession(request: Request, env: Env): Promise<Respons
     parsed.durationSeconds, parsed.commits, parsed.linesAdded, parsed.linesRemoved,
     parsed.filesTouched, momentum, submittedAt,
   ).run();
+
+  // The upsert's WHERE guard silently refuses a session id owned by someone
+  // else; surface that instead of pretending success, and never write events
+  // for a session this user doesn't own.
+  const owner = await env.DB.prepare(
+    `SELECT user_github_id AS uid FROM sessions WHERE id = ?`,
+  ).bind(parsed.id).first<{ uid: number }>();
+  if (owner && owner.uid !== auth.sub) return error(409, 'session id belongs to another user');
+
+  // One row per (session, day). Pre-0.8 CLIs send no shipEvents; derive the
+  // single end-day event from momentum, which is exactly the old counting.
+  // The submitted set replaces the session's rows, so corrections (grace
+  // rescore, changed end day) reconcile in both directions.
+  const eventDays = [...new Set(parsed.shipEvents ?? (momentum === 'shipped' ? [parsed.endedAt.slice(0, 10)] : []))].sort();
+  await env.DB.prepare(
+    `DELETE FROM ship_events WHERE session_id = ?${eventDays.length ? ` AND day NOT IN (${eventDays.map(() => '?').join(',')})` : ''}`,
+  ).bind(parsed.id, ...eventDays).run();
+  for (const day of eventDays) {
+    const capped = await env.DB.prepare(
+      `SELECT COUNT(*) AS n FROM ship_events WHERE user_github_id = ? AND day = ? AND session_id != ?`,
+    ).bind(auth.sub, day, parsed.id).first<{ n: number }>();
+    if ((capped?.n ?? 0) >= DAILY_SHIPPED_CAP) continue;
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO ship_events (session_id, user_github_id, day) VALUES (?, ?, ?)`,
+    ).bind(parsed.id, auth.sub, day).run();
+  }
 
   await env.DB.prepare(`UPDATE users SET last_seen_at = ? WHERE github_id = ?`).bind(submittedAt, auth.sub).run();
 

--- a/server/src/views/leaderboard.ts
+++ b/server/src/views/leaderboard.ts
@@ -21,7 +21,7 @@ function relativeTime(iso: string, now: Date): string {
 function heatmapCells(recent: HeatmapDay[]): string {
   return recent.map(({ day, n }) => {
     const cls = n === 0 ? 'cell-0' : n === 1 ? 'cell-1' : n <= 3 ? 'cell-2' : 'cell-3';
-    const noun = n === 1 ? 'shipped session' : 'shipped sessions';
+    const noun = n === 1 ? 'ship' : 'ships';
     return `<span class="cell ${cls}" title="${escapeHtml(day)} · ${n} ${noun}" aria-hidden="true"></span>`;
   }).join('');
 }
@@ -52,7 +52,7 @@ function windowRange(start: Date, now: Date): string {
 export function renderLeaderboard(data: LeaderboardData, window: Window, updatedAt: Date, windowStart?: Date | null): string {
   const { entries, devCount, sessionCount } = data;
   const devNoun = devCount === 1 ? 'developer' : 'developers';
-  const sessionNoun = sessionCount === 1 ? 'shipped session' : 'shipped sessions';
+  const sessionNoun = sessionCount === 1 ? 'ship' : 'ships';
   const rangeLabel = windowStart ? ` <span class="range">· ${windowRange(windowStart, updatedAt)}</span>` : '';
   const scaleLine = entries.length === 0
     ? ''
@@ -180,7 +180,7 @@ vibe login</pre>
     more
   </div>
   <footer>
-    <div class="definition"><strong style="color:#777">shipped</strong> = a session with at least one commit and meaningful changes (≥50 lines or ≥3 files).</div>
+    <div class="definition"><strong style="color:#777">shipped</strong> = a day a session landed at least one commit with meaningful changes (≥50 lines or ≥3 files). A session that ships across several days counts each day.</div>
     <div class="links"><a href="https://github.com/iamnotstatic/vibetime">github.com/iamnotstatic/vibetime</a> · <code>npm i -g vibetime-cli</code></div>
   </footer>
 </main>

--- a/src/db.ts
+++ b/src/db.ts
@@ -38,6 +38,11 @@ export interface Session {
   // if it then goes idle, the reaper re-finalizes it as the clean end it already
   // had instead of downgrading it to `interrupted`.
   hadCleanEnd?: boolean;
+  // UTC days this session shipped on (one leaderboard point each), and the
+  // stats snapshot at the last emitted event. Maintained by trackShipEvents in
+  // score.ts; a multi-day session earns each day's event with that day's work.
+  shipEvents?: string[];
+  eventBaseline?: { commits: number; linesAdded: number; linesRemoved: number; filesTouched: number };
 }
 
 interface DbSchema {

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -3,7 +3,7 @@ import { addSession, updateSession, getSessions, INACTIVITY_TIMEOUT_MS, type Ses
 import { isGitRepo, getHeadSha, getDiffStats, getReposDiffStats, baselineRepos, describeRepos, type GitDiffStats } from './git.js';
 import { refreshAndReap } from './rescore.js';
 import { readConfig } from './config.js';
-import { scoreSession } from './score.js';
+import { scoreSession, trackShipEvents } from './score.js';
 import { flushPendingSubmissions } from './submit.js';
 
 // Claude Code and Codex deliver a JSON payload on stdin to every hook command.
@@ -176,8 +176,10 @@ async function onActivity(sessionId: string, cwd: string): Promise<void> {
   if (reopen || gap >= GIT_REFRESH_MS) {
     const stats = diffFor(session, cwd);
     if (stats) {
+      const config = readConfig();
       Object.assign(updates, stats);
-      updates.momentum = scoreSession({ ...stats, exitCode: -1 }, readConfig());
+      updates.momentum = scoreSession({ ...stats, exitCode: -1 }, config);
+      Object.assign(updates, trackShipEvents(session, stats, config, now) ?? {});
     }
   }
 
@@ -195,12 +197,13 @@ async function onSessionEnd(sessionId: string, cwd: string): Promise<void> {
   if (session.exitCode !== -1 && !reopen) return; // finalized — stale events can't revive it
 
   const stats = diffFor(session, cwd);
+  const config = readConfig();
   const updates: Partial<Session> = {
     endedAt: new Date(now).toISOString(),
     durationSeconds: session.durationSeconds + (reopen === 'reaped' ? 0 : activeSecondsSince(session.lastActivityAt, session.startedAt, now)),
     // Rescore as a clean end even when the repos can't be measured (moved or
     // deleted): the recorded stats stand, but a reaped `interrupted` must not.
-    momentum: scoreSession({ ...(stats ?? session), exitCode: 0 }, readConfig()),
+    momentum: scoreSession({ ...(stats ?? session), exitCode: 0 }, config),
     exitCode: 0,
     hadCleanEnd: true,
     lastActivityAt: new Date(now).toISOString(),
@@ -208,6 +211,7 @@ async function onSessionEnd(sessionId: string, cwd: string): Promise<void> {
     submittedAt: undefined,
   };
   if (stats) Object.assign(updates, stats);
+  Object.assign(updates, trackShipEvents(session, stats ?? session, config, now) ?? {});
 
   try {
     await updateSession(sessionId, updates);

--- a/src/rescore.ts
+++ b/src/rescore.ts
@@ -1,7 +1,7 @@
 import { getSessions, updateSession, reapOrphanedSessions, INACTIVITY_TIMEOUT_MS, type Session } from './db.js';
 import { getReposDiffStats } from './git.js';
 import { readConfig } from './config.js';
-import { scoreSession } from './score.js';
+import { scoreSession, trackShipEvents } from './score.js';
 
 // How long after a session ends its work can still land. You close the tab and
 // commit from the terminal a minute later; you step away mid-task and come back
@@ -66,6 +66,7 @@ export async function refreshRecentSessions(): Promise<void> {
 
     await updateSession(session.id, {
       ...stats,
+      ...(trackShipEvents(session, stats, config, now) ?? {}),
       momentum: scoreSession({ ...stats, exitCode: session.exitCode }, config),
       // The corrected state has to reach the server; it upserts on id, so
       // resubmitting is safe.

--- a/src/score.ts
+++ b/src/score.ts
@@ -27,6 +27,64 @@ export function scoreSession(session: Scoreable, thresholds: Thresholds): Moment
   return 'idle';
 }
 
+export interface ShipStats {
+  commits: number;
+  linesAdded: number;
+  linesRemoved: number;
+  filesTouched: number;
+}
+
+export interface ShipEventState {
+  shipEvents?: string[];
+  eventBaseline?: ShipStats;
+}
+
+// A session can span days; ship events record which UTC days it actually
+// shipped on, so a three-day session counts three times on the leaderboard
+// instead of once on its end day. Bounded well past MAX_AGE_MS on the server.
+const MAX_SHIP_EVENTS = 62;
+
+function utcDay(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// Emit a ship event when the work done SINCE THE LAST EVENT would qualify as
+// shipped on its own — cumulative stats always qualify once they ever did, so
+// day two must earn its event with day two's commits. At most one event per
+// UTC day per session. Pure: returns the fields to persist, or null when
+// nothing changed. filesTouched is a set size, not additive, so its delta
+// undercounts on later days; lines and commits carry the signal there.
+export function trackShipEvents(prior: ShipEventState, stats: ShipStats, thresholds: Thresholds, nowMs: number): Required<ShipEventState> | null {
+  const events = prior.shipEvents ?? [];
+  const prev = prior.eventBaseline ?? { commits: 0, linesAdded: 0, linesRemoved: 0, filesTouched: 0 };
+
+  // Stats can shrink (grace-window rescore, worktree dedupe, a moved repo);
+  // a baseline above current stats would block every future event, so clamp
+  // it down and persist the clamp.
+  const base: ShipStats = {
+    commits: Math.min(prev.commits, stats.commits),
+    linesAdded: Math.min(prev.linesAdded, stats.linesAdded),
+    linesRemoved: Math.min(prev.linesRemoved, stats.linesRemoved),
+    filesTouched: Math.min(prev.filesTouched, stats.filesTouched),
+  };
+  const delta: Scoreable = {
+    commits: stats.commits - base.commits,
+    linesAdded: stats.linesAdded - base.linesAdded,
+    linesRemoved: stats.linesRemoved - base.linesRemoved,
+    filesTouched: stats.filesTouched - base.filesTouched,
+    exitCode: 0,
+  };
+
+  const day = utcDay(nowMs);
+  if (scoreSession(delta, thresholds) === 'shipped' && !events.includes(day) && events.length < MAX_SHIP_EVENTS) {
+    return { shipEvents: [...events, day], eventBaseline: { ...stats } };
+  }
+  if (base.commits !== prev.commits || base.linesAdded !== prev.linesAdded || base.linesRemoved !== prev.linesRemoved || base.filesTouched !== prev.filesTouched) {
+    return { shipEvents: events, eventBaseline: base };
+  }
+  return null;
+}
+
 export const TIER_FILLED: Record<MomentumTier, number> = {
   shipped: 8,
   progressed: 6,

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -25,8 +25,13 @@ function buildPayload(s: Session): Record<string, unknown> {
     filesTouched: s.filesTouched,
     momentum: s.momentum,
     // Absent on sessions recorded by a pre-0.8 CLI; the server derives a
-    // single end-day event from momentum for those.
-    ...(s.shipEvents?.length ? { shipEvents: s.shipEvents } : {}),
+    // single end-day event from momentum for those. The server rejects more
+    // event days than commits, and stats can shrink after events were emitted
+    // (dedupe, rescore), so send at most `commits` days, newest first — the
+    // ones still backed by the current stats.
+    ...(s.shipEvents?.length && s.commits > 0
+      ? { shipEvents: s.shipEvents.slice(-Math.min(s.commits, s.shipEvents.length)) }
+      : {}),
   };
 }
 

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -24,6 +24,9 @@ function buildPayload(s: Session): Record<string, unknown> {
     linesRemoved: s.linesRemoved,
     filesTouched: s.filesTouched,
     momentum: s.momentum,
+    // Absent on sessions recorded by a pre-0.8 CLI; the server derives a
+    // single end-day event from momentum for those.
+    ...(s.shipEvents?.length ? { shipEvents: s.shipEvents } : {}),
   };
 }
 

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -4,7 +4,7 @@ import { addSession, updateSession, deleteSession, INACTIVITY_TIMEOUT_MS, type S
 import { baselineRepos, describeRepos, getReposDiffStats, getReposFingerprint } from './git.js';
 import { refreshAndReap } from './rescore.js';
 import { readConfig } from './config.js';
-import { scoreSession } from './score.js';
+import { scoreSession, trackShipEvents, type ShipEventState } from './score.js';
 import { renderEndcard } from './render.js';
 import { flushPendingSubmissions, submitInProgress } from './submit.js';
 import { getRecommendedVersion } from './api.js';
@@ -55,7 +55,9 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
 
   await refreshAndReap();
 
-  function snapshot(exitCode: number): Pick<Session, 'endedAt' | 'durationSeconds' | 'commits' | 'linesAdded' | 'linesRemoved' | 'filesTouched' | 'momentum' | 'exitCode' | 'lastActivityAt'> {
+  let eventState: ShipEventState = {};
+
+  function snapshot(exitCode: number): Pick<Session, 'endedAt' | 'durationSeconds' | 'commits' | 'linesAdded' | 'linesRemoved' | 'filesTouched' | 'momentum' | 'exitCode' | 'lastActivityAt' | 'shipEvents' | 'eventBaseline'> {
     const endedAt = new Date().toISOString();
     const endMs = new Date(endedAt).getTime();
     const startMs = new Date(startedAt).getTime();
@@ -67,7 +69,9 @@ export async function wrapTool(tool: string, args: string[]): Promise<void> {
       diffStats = getReposDiffStats(repos);
     }
     const momentum = scoreSession({ ...diffStats, exitCode }, config);
-    return { endedAt, durationSeconds, ...diffStats, momentum, exitCode, lastActivityAt };
+    const tracked = trackShipEvents(eventState, diffStats, config, endMs);
+    if (tracked) eventState = tracked;
+    return { endedAt, durationSeconds, ...diffStats, momentum, exitCode, lastActivityAt, ...eventState };
   }
 
   // write session immediately so it survives crashes

--- a/test/ship-events.test.mjs
+++ b/test/ship-events.test.mjs
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { trackShipEvents } = await import('../dist/score.js');
+
+const T = { thresholdLines: 50, thresholdFiles: 3 };
+const DAY1 = Date.UTC(2026, 8, 1, 10);
+const DAY1_LATER = Date.UTC(2026, 8, 1, 20);
+const DAY2 = Date.UTC(2026, 8, 2, 10);
+const DAY3 = Date.UTC(2026, 8, 3, 10);
+
+function stats(commits, lines, files = 1) {
+  return { commits, linesAdded: lines, linesRemoved: 0, filesTouched: files };
+}
+
+test('first shipped crossing emits an event and sets the baseline', () => {
+  const r = trackShipEvents({}, stats(1, 80), T, DAY1);
+  assert.deepEqual(r.shipEvents, ['2026-09-01']);
+  assert.deepEqual(r.eventBaseline, stats(1, 80));
+});
+
+test('below-threshold work emits nothing', () => {
+  assert.equal(trackShipEvents({}, stats(1, 10), T, DAY1), null); // commit, not meaningful
+  assert.equal(trackShipEvents({}, stats(0, 200), T, DAY1), null); // meaningful, no commit
+});
+
+test('a second crossing the same day does not duplicate', () => {
+  const first = trackShipEvents({}, stats(1, 80), T, DAY1);
+  const again = trackShipEvents(first, stats(3, 400), T, DAY1_LATER);
+  assert.equal(again, null);
+});
+
+test('day two earns its event with day two work', () => {
+  const first = trackShipEvents({}, stats(1, 80), T, DAY1);
+  // only 5 more lines on day 2: no event
+  assert.equal(trackShipEvents(first, stats(1, 85), T, DAY2), null);
+  // a fresh commit with meaningful new lines: event
+  const second = trackShipEvents(first, stats(2, 200), T, DAY2);
+  assert.deepEqual(second.shipEvents, ['2026-09-01', '2026-09-02']);
+  assert.deepEqual(second.eventBaseline, stats(2, 200));
+});
+
+test('carryover: sub-threshold days accumulate until a crossing', () => {
+  const first = trackShipEvents({}, stats(1, 80), T, DAY1);
+  // day 2: 40 new lines, no commit — nothing
+  assert.equal(trackShipEvents(first, stats(1, 120), T, DAY2), null);
+  // day 3: one commit, 20 more lines — delta since day 1 is 1 commit / 60 lines
+  const third = trackShipEvents(first, stats(2, 140), T, DAY3);
+  assert.deepEqual(third.shipEvents, ['2026-09-01', '2026-09-03']);
+});
+
+test('shrunken stats re-clamp the baseline instead of wedging detection', () => {
+  const first = trackShipEvents({}, stats(2, 300), T, DAY1);
+  // rescore/dedupe drops the totals below the baseline
+  const clamped = trackShipEvents(first, stats(1, 100), T, DAY2);
+  assert.deepEqual(clamped.shipEvents, ['2026-09-01']);
+  assert.deepEqual(clamped.eventBaseline, stats(1, 100));
+  // new work on top of the clamped baseline can still ship
+  const second = trackShipEvents(clamped, stats(2, 180), T, DAY2);
+  assert.deepEqual(second.shipEvents, ['2026-09-01', '2026-09-02']);
+});
+
+test('the event list is capped', () => {
+  let state = {};
+  let s = stats(0, 0);
+  for (let i = 0; i < 70; i++) {
+    s = stats(s.commits + 1, s.linesAdded + 100);
+    const r = trackShipEvents(state, s, T, DAY1 + i * 24 * 3600 * 1000);
+    if (r) state = r;
+  }
+  assert.equal(state.shipEvents.length, 62);
+});
+
+test('files-only meaningfulness works on the delta', () => {
+  const first = trackShipEvents({}, { commits: 1, linesAdded: 10, linesRemoved: 0, filesTouched: 6 }, T, DAY1);
+  assert.deepEqual(first.shipEvents, ['2026-09-01']);
+});


### PR DESCRIPTION
The last structural item on the foundation list: a session that ships across several days counts once per day it shipped, not once on its end day.

## How events are detected (CLI)

`trackShipEvents` in score.ts, pure, called from the four places stats refresh (wrapper snapshot, hook activity, hook session-end, grace rescore):

- An event fires when the work done SINCE THE LAST EVENT would qualify as shipped on its own. Cumulative stats always qualify once they ever did, so day two has to earn its event with day two's commits.
- At most one event per UTC day per session (UTC matches the leaderboard's day grouping).
- Sub-threshold days carry over: 40 lines on Tuesday plus a commit on Wednesday ships Wednesday.
- Stats can shrink (grace rescore, worktree dedupe, moved repos); the baseline re-clamps down so detection can't wedge.
- Events persist once emitted, including through a later crash: day one's commits shipped even if day three ended in an interrupt.
- filesTouched is a set size, not additive, so its delta undercounts later days; lines and commits carry the signal.

## Server

- `ship_events` table (migration 0004), backfilled from existing shipped sessions as single end-day events: history is continuous and pre-migration counts are identical.
- Pre-0.8 clients send no shipEvents; the server derives the end-day event from momentum, which is exactly the old counting. Old CLIs keep working forever.
- The submitted day list replaces the session's rows, so corrections reconcile in both directions.
- Leaderboard ranks, totals, and heatmaps come from ship_events; last-shipped timestamps still come from the underlying sessions. Labels say "ships".
- Anti-gaming cap moves from 10 shipped sessions per rolling 24h (429) to 10 events per user per UTC day, enforced by dropping excess event rows while the session still stores. Clients never see a cap error and never retry into it.
- Session-id hijack now returns 409 instead of a silent 200 (closes the old foundation item), and events are never written for a session the submitter doesn't own.
- Event days are validated: date shape, max 62, and must fall within the session's lifespan with a day of slack.

## Testing

- 44/44 tests (8 new on the tracker: crossings, same-day dedupe, day-two earning, carryover, baseline re-clamp, cap, files-only delta).
- Server typecheck; migration applies cleanly.
- Live e2e against wrangler dev: 3-day event submission, legacy derivation, hijack 409, correction resubmit reconciling 4 ships down to 3, per-day cap dropping the 11th event on a full day.
- Real hook-session lifecycle through the CLI binary records shipEvents and the baseline locally.

## Release

Ships as v0.8.0. Server first (migration 0004 + deploy), then npm publish, then recommend + redeploy. The leaderboard switches to event counting the moment the server deploys, backfill included, independent of CLI rollout.
