### PR TITLE
feat: support Fish shell hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,12 @@ npm install -g vibetime-cli
 
 ```
 vibe init
-source ~/.zshrc   # or ~/.bashrc — or restart your terminal
+source ~/.zshrc   # or ~/.bashrc / ~/.config/fish/config.fish
 ```
 
 One command sets up everything: shell hooks that wrap `claude`, `codex`, and `gemini` in the terminal, plus desktop session hooks for the Claude Code and Codex apps (see [Desktop apps](#desktop-apps)). The tools work exactly the same — Vibetime tracks your git state while you code and prints the endcard when you're done.
 
-**Fish shell** — `vibe init` writes bash/zsh syntax. Fish users should add hooks manually to `~/.config/fish/config.fish`:
-
-```fish
-function claude; vibe __wrap claude $argv; end
-```
+Fish, Bash, and Zsh are detected automatically, and `vibe init` writes the matching syntax to the shell's rc file.
 
 ## What you get
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,7 +62,7 @@ export function addTool(name: string): void {
     return;
   }
 
-  const { rcFile } = detectShell();
+  const { shell, rcFile } = detectShell();
 
   if (!existsSync(rcFile)) {
     console.log(`\n  ${RED('✗')} run vibe init first to set up Vibetime.\n`);
@@ -71,7 +71,7 @@ export function addTool(name: string): void {
 
   // A default tool is only "already added by vibe init" while its hooks are
   // actually in the rc file — after a remove-tool it can be re-added.
-  const added = appendHook(name, rcFile);
+  const added = appendHook(name, rcFile, shell);
   if (added) {
     console.log(`\n  ${PURPLE('◆')} ${name} added. restart your terminal to start tracking.\n`);
   } else if (DEFAULT_TOOLS.includes(name.toLowerCase())) {

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,15 +1,21 @@
-import { existsSync, readFileSync, appendFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, appendFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { PURPLE } from './colors.js';
 
 const HOOK_MARKER = '# vibetime hooks';
 export const DEFAULT_TOOLS = ['claude', 'codex', 'gemini'];
+export type Shell = 'bash' | 'zsh' | 'fish';
 
-function hookLines(tool: string): string {
+function hookLines(tool: string, shell: Shell = 'bash'): string {
   const lower = tool.toLowerCase();
   const title = lower.charAt(0).toUpperCase() + lower.slice(1);
   const upper = lower.toUpperCase();
+  if (shell === 'fish') {
+    return [lower, title, upper]
+      .map(name => `function ${name}; vibe __wrap ${lower} $argv; end`)
+      .join('\n');
+  }
   return [
     `${lower}() { vibe __wrap ${lower} "$@"; }`,
     `${title}() { vibe __wrap ${lower} "$@"; }`,
@@ -17,15 +23,18 @@ function hookLines(tool: string): string {
   ].join('\n');
 }
 
-export function detectShell(): { shell: string; rcFile: string } {
+export function detectShell(): { shell: Shell; rcFile: string } {
   const shellEnv = process.env.SHELL || '/bin/zsh';
+  if (shellEnv.includes('fish')) {
+    return { shell: 'fish', rcFile: join(homedir(), '.config', 'fish', 'config.fish') };
+  }
   if (shellEnv.includes('zsh')) {
     return { shell: 'zsh', rcFile: join(homedir(), '.zshrc') };
   }
   return { shell: 'bash', rcFile: join(homedir(), '.bashrc') };
 }
 
-export function appendHook(tool: string, rcFile: string): boolean {
+export function appendHook(tool: string, rcFile: string, shell: Shell = 'bash'): boolean {
   const lower = tool.toLowerCase();
 
   if (existsSync(rcFile)) {
@@ -34,7 +43,8 @@ export function appendHook(tool: string, rcFile: string): boolean {
     if (content.includes(`vibe __wrap ${lower} `)) return false;
   }
 
-  appendFileSync(rcFile, `\n${hookLines(lower)}\n`);
+  mkdirSync(dirname(rcFile), { recursive: true });
+  appendFileSync(rcFile, `\n${hookLines(lower, shell)}\n`);
   return true;
 }
 
@@ -45,7 +55,9 @@ export function removeHook(tool: string, rcFile: string): boolean {
   const content = readFileSync(rcFile, 'utf-8');
   // Only hook definitions for this tool — a line that merely mentions the
   // wrap command (a comment, an alias) is the user's, not ours.
-  const HOOK_RE = new RegExp(`^[a-zA-Z0-9_-]+\\(\\) \\{ vibe __wrap ${lower} `);
+  const HOOK_RE = new RegExp(
+    `^(?:[a-zA-Z0-9_-]+\\(\\) \\{ vibe __wrap ${lower} |function [a-zA-Z0-9_-]+; vibe __wrap ${lower} \\$argv; end$)`,
+  );
   const filtered = content.split('\n').filter((line) => !HOOK_RE.test(line));
 
   const cleaned = filtered.join('\n');
@@ -68,14 +80,17 @@ export function initShellHooks(): void {
   }
 
   const block = `\n${HOOK_MARKER}\n` +
-    DEFAULT_TOOLS.map(t => hookLines(t)).join('\n') +
+    DEFAULT_TOOLS.map(t => hookLines(t, shell)).join('\n') +
     '\n';
+  mkdirSync(dirname(rcFile), { recursive: true });
   appendFileSync(rcFile, block);
 
   console.log(`\n  ${PURPLE('◆')} vibetime hooks added to ${rcFile} (${shell})\n`);
   console.log(`  added:`);
   for (const t of DEFAULT_TOOLS) {
-    console.log(`    ${t}() { vibe __wrap ${t} "$@"; }`);
+    console.log(shell === 'fish'
+      ? `    function ${t}; vibe __wrap ${t} $argv; end`
+      : `    ${t}() { vibe __wrap ${t} "$@"; }`);
   }
   console.log(`\n  restart your shell or run: source ${rcFile}\n`);
 }
@@ -90,7 +105,7 @@ export function removeShellHooks(): void {
 
   const content = readFileSync(rcFile, 'utf-8');
 
-  const HOOK_RE = /^[a-zA-Z0-9_-]+\(\) \{ vibe __wrap /;
+  const HOOK_RE = /^(?:[a-zA-Z0-9_-]+\(\) \{ vibe __wrap |function [a-zA-Z0-9_-]+; vibe __wrap .* \$argv; end$)/;
   const lines = content.split('\n');
   const filtered: string[] = [];
   let inBlock = false;

--- a/test/shell-hooks.test.mjs
+++ b/test/shell-hooks.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { appendHook, removeHook } from '../dist/init.js';
+import { appendHook, detectShell, removeHook } from '../dist/init.js';
 
 function scratchRc(t, content = '# my rc\nexport PATH=$PATH\n') {
   const dir = mkdtempSync(join(tmpdir(), 'vibe-rc-'));
@@ -72,4 +72,30 @@ test('a user line that merely mentions the wrap command is not ours to delete', 
   const rcFile = scratchRc(t, '# reminder: opencode() { vibe __wrap opencode "$@"; } is what vibe adds\nalias oc=opencode\n');
   assert.equal(removeHook('opencode', rcFile), false);
   assert.ok(readFileSync(rcFile, 'utf-8').includes('alias oc=opencode'));
+});
+
+test('fish hooks use fish syntax and round-trip cleanly', (t) => {
+  const rcFile = scratchRc(t);
+  const before = readFileSync(rcFile, 'utf-8');
+
+  assert.equal(appendHook('opencode', rcFile, 'fish'), true);
+  const withHooks = readFileSync(rcFile, 'utf-8');
+  assert.match(withHooks, /function opencode; vibe __wrap opencode \$argv; end/);
+  assert.ok(!withHooks.includes('"$@"'));
+
+  assert.equal(removeHook('opencode', rcFile), true);
+  assert.equal(readFileSync(rcFile, 'utf-8').trim(), before.trim());
+});
+
+test('fish is detected with its standard config path', (t) => {
+  const previousShell = process.env.SHELL;
+  t.after(() => {
+    if (previousShell === undefined) delete process.env.SHELL;
+    else process.env.SHELL = previousShell;
+  });
+  process.env.SHELL = '/opt/homebrew/bin/fish';
+
+  const detected = detectShell();
+  assert.equal(detected.shell, 'fish');
+  assert.ok(detected.rcFile.endsWith('/.config/fish/config.fish'));
 });


### PR DESCRIPTION
Fixes #1.

Detects Fish and writes Fish functions to `~/.config/fish/config.fish`. Add/remove/uninstall now handle the same syntax, with regression coverage for generation, cleanup, and shell detection.

Tested: `npm test` (46 passed).
